### PR TITLE
Use Montgomery reductions instead of Barrett reductions

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -14,58 +14,30 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::convert::TryInto;
 use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::str::FromStr;
 
+use num::{BigUint, FromPrimitive};
 use num::integer::Integer;
+use num::traits::cast::ToPrimitive;
+use num::traits::identities::One;
 use rand::RngCore;
 use rand::rngs::OsRng;
 use unroll::unroll_for_loops;
 
-use lazy_static::lazy_static;
-
 use crate::conversions::{biguint_to_u64_vec, u64_slice_to_biguint};
-use crate::num_util::inverse;
-
-lazy_static! {
-    /// Precomputed R for the Barrett reduction algorithm.
-    static ref BLS12_BASE_BARRETT_R: [u64; 6] = {
-        // 4^k in binary is 1 followed by 2*377 0s.
-        let four_exp_k = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 << 50];
-        let (q_12, _r) = div_12_6(four_exp_k, Bls12Base::ORDER);
-
-        // The more-significant half of the limbs should all be zero after the division.
-        for i in 6..12 {
-            debug_assert_eq!(q_12[i], 0);
-        }
-
-        (&q_12[0..6]).try_into().unwrap()
-    };
-
-    /// Precomputed R for the Barrett reduction algorithm.
-    static ref BLS12_SCALAR_BARRETT_R: [u64; 4] = {
-        // 4^k in binary is 1 followed by 2*253 0s.
-        let four_exp_k = [0, 0, 0, 0, 0, 0, 0, 1 << 58];
-        let (q_8, _r) = div_8_4(four_exp_k, Bls12Scalar::ORDER);
-
-        // The more-significant half of the limbs should all be zero after the division.
-        for i in 4..8 {
-            debug_assert_eq!(q_8[i], 0);
-        }
-
-        (&q_8[0..4]).try_into().unwrap()
-    };
-}
+use crate::num_util::modinv;
 
 /// An element of the BLS12 group's base field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Bls12Base {
-    /// The limbs in little-endian form.
+    /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 6],
 }
 
 /// An element of the BLS12 group's scalar field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Bls12Scalar {
-    /// The limbs in little-endian form.
+    /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],
 }
 
@@ -80,6 +52,35 @@ impl Bls12Base {
     pub const ORDER: [u64; 6] = [9586122913090633729, 1660523435060625408, 2230234197602682880,
         1883307231910630287, 14284016967150029115, 121098312706494698];
 
+    /// R in the context of the Montgomery reduction, i.e. 2^384 % |F|.
+    pub(crate) const R: [u64; 6] = [202099033278250856, 5854854902718660529, 11492539364873682930,
+        8885205928937022213, 5545221690922665192, 39800542322357402];
+
+    /// R^2 in the context of the Montgomery reduction, i.e. 2^384^2 % |F|.
+    pub(crate) const R2: [u64; 6] = [13224372171368877346, 227991066186625457, 2496666625421784173,
+        13825906835078366124, 9475172226622360569, 30958721782860680];
+
+    /// R^3 in the context of the Montgomery reduction, i.e. 2^384^3 % |F|.
+    pub(crate) const R3: [u64; 6] = [6349885463227391520, 16505482940020594053, 3163973454937060627,
+        7650090842119774734, 4571808961100582073, 73846176275226021];
+
+    /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
+    const MU: u64 = 9586122913090633727;
+
+    fn from_canonical(c: [u64; 6]) -> Self {
+        // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
+        Self { limbs: Self::montgomery_multiply(c, Self::R2) }
+    }
+
+    fn from_canonical_u64(c: u64) -> Self {
+        Self::from_canonical([c, 0, 0, 0, 0, 0])
+    }
+
+    fn to_canonical(&self) -> [u64; 6] {
+        // Let x * R = self. We compute M(x * R, 1) = x * R * R^-1 = x.
+        Self::montgomery_multiply(self.limbs, [1, 0, 0, 0, 0, 0])
+    }
+
     pub fn double(&self) -> Self {
         // TODO: Shift instead of adding.
         *self + *self
@@ -91,27 +92,64 @@ impl Bls12Base {
     }
 
     pub fn multiplicative_inverse(&self) -> Option<Self> {
+        // TODO: This assumes canonical representation. Need to M-multiply by R^3.
         let self_biguint = u64_slice_to_biguint(&self.limbs);
         let order_biguint = u64_slice_to_biguint(&Self::ORDER);
-        let opt_inverse_biguint = inverse(self_biguint, &order_biguint);
+        let opt_inverse_biguint = modinv(self_biguint, order_biguint);
 
         opt_inverse_biguint.map(|inverse_biguint| Self {
             limbs: biguint_to_u64_vec(inverse_biguint, 6).as_slice().try_into().unwrap()
         })
     }
-}
 
-impl From<u64> for Bls12Base {
-    fn from(n: u64) -> Self {
-        Bls12Base { limbs: [n, 0, 0, 0, 0, 0] }
+    #[unroll_for_loops]
+    fn montgomery_multiply(a: [u64; 6], b: [u64; 6]) -> [u64; 6] {
+        // Interleaved Montgomery multiplication, as described in Algorithm 2 of
+        // https://eprint.iacr.org/2017/1057.pdf
+
+        // Note that in the loop below, to avoid explicitly shifting c, we will treat i as the least
+        // significant digit and wrap around.
+        let mut c = [0u64; 7];
+
+        for i in 0..6 {
+            // Add a[i] b to c.
+            let mut carry = 0;
+            for j in 0..6 {
+                let result = c[(i + j) % 7] as u128 + a[i] as u128 * b[j] as u128 + carry as u128;
+                c[(i + j) % 7] = result as u64;
+                carry = (result >> 64) as u64;
+            }
+            c[(i + 6) % 7] += carry;
+
+            // q = u c mod r = u c[0] mod r.
+            let q = Bls12Base::MU.wrapping_mul(c[i]);
+
+            // C += N q
+            carry = 0;
+            for j in 0..6 {
+                let result = c[(i + j) % 7] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
+                c[(i + j) % 7] = result as u64;
+                carry = (result >> 64) as u64;
+            }
+            c[(i + 6) % 7] += carry;
+
+            debug_assert_eq!(c[i], 0);
+        }
+
+        let mut result = [c[6], c[0], c[1], c[2], c[3], c[4]];
+        // Final conditional subtraction.
+        if cmp_6_6(result, Self::ORDER) != Ordering::Less {
+            result = sub_6_6(result, Self::ORDER);
+        }
+        result
     }
 }
 
 impl Bls12Scalar {
     pub const ZERO: Self = Self { limbs: [0; 4] };
-    pub const ONE: Self = Self { limbs: [1, 0, 0, 0] };
-    pub const TWO: Self = Self { limbs: [2, 0, 0, 0] };
-    pub const THREE: Self = Self { limbs: [3, 0, 0, 0] };
+    pub const ONE: Self = Self { limbs: [9015221291577245683, 8239323489949974514, 1646089257421115374, 958099254763297437] };
+    pub const TWO: Self = Self { limbs: [17304940830682775525, 10017539527700119523, 14770643272311271387, 570918138838421475] };
+    pub const THREE: Self = Self { limbs: [7147916296078753751, 11795755565450264533, 9448453213491875784, 183737022913545514] };
 
     pub const BITS: usize = 253;
 
@@ -119,19 +157,47 @@ impl Bls12Scalar {
     /// 8444461749428370424248824938781546531375899335154063827935233455917409239041
     pub const ORDER: [u64; 4] = [725501752471715841, 6461107452199829505, 6968279316240510977, 1345280370688173398];
 
+    /// R in the context of the Montgomery reduction, i.e. 2^256 % |F|.
+    pub(crate) const R: [u64; 4] =
+        [9015221291577245683, 8239323489949974514, 1646089257421115374, 958099254763297437];
+
+    /// R^2 in the context of the Montgomery reduction, i.e. 2^256^2 % |F|.
+    pub(crate) const R2: [u64; 4] =
+        [2726216793283724667, 14712177743343147295, 12091039717619697043, 81024008013859129];
+
+    /// R^3 in the context of the Montgomery reduction, i.e. 2^256^3 % |F|.
+    pub(crate) const R3: [u64; 4] =
+        [7656847007262524748, 7083357369969088153, 12818756329091487507, 432872940405820890];
+
+    /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
+    const MU: u64 = 725501752471715839;
+
     pub const TWO_ADICITY: usize = 47;
 
     /// Generator of [1, order).
-    const GENERATOR: Bls12Scalar = Bls12Scalar { limbs: [11, 0, 0, 0] };
+    const GENERATOR: Bls12Scalar = Bls12Scalar { limbs: [
+        1855201571499933546, 8511318076631809892, 6222514765367795509, 1122129207579058019] };
 
-    /// 60001509534603559531609739528203892656505753216962260608619555
-    const T: Bls12Scalar = Self { limbs: [17149038877957297187, 11113960768935211860, 14608890324369326440, 9558] };
+    fn from_canonical(c: [u64; 4]) -> Self {
+        // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
+        Self { limbs: Self::montgomery_multiply(c, Self::R2) }
+    }
+
+    fn from_canonical_u64(c: u64) -> Self {
+        Self::from_canonical([c, 0, 0, 0])
+    }
+
+    fn to_canonical(&self) -> [u64; 4] {
+        // Let x * R = self. We compute M(x * R, 1) = x * R * R^-1 = x.
+        Self::montgomery_multiply(self.limbs, [1, 0, 0, 0])
+    }
 
     /// Computes a `2^n_power`th primitive root of unity.
     pub fn primitive_root_of_unity(n_power: usize) -> Bls12Scalar {
         assert!(n_power <= 47);
-        let base_root = Self::GENERATOR.exp(Self::T);
-        base_root.exp((1u64 << 47u64 - n_power as u64).into())
+        let t = BigUint::from_str("60001509534603559531609739528203892656505753216962260608619555").unwrap();
+        let base_root = Self::GENERATOR.exp(t);
+        base_root.exp(BigUint::from_u64(1u64 << 47u64 - n_power as u64).unwrap())
     }
 
     pub fn cyclic_subgroup_unknown_order(generator: Bls12Scalar) -> Vec<Bls12Scalar> {
@@ -162,12 +228,12 @@ impl Bls12Scalar {
         Self::cyclic_subgroup_unknown_order(generator).len()
     }
 
-    pub fn exp(&self, power: Bls12Scalar) -> Bls12Scalar {
+    pub fn exp(&self, power: BigUint) -> Bls12Scalar {
         let mut current = *self;
         let mut product = Bls12Scalar::ONE;
-        for limb in power.limbs.iter() {
-            for i in 0..64 {
-                if (limb >> i & 1u64) != 0u64 {
+        for byte in power.to_bytes_le() {
+            for i in 0..8 {
+                if (byte >> i & 1) != 0 {
                     product = product * current;
                 }
                 current = current.square();
@@ -182,12 +248,17 @@ impl Bls12Scalar {
     }
 
     pub fn multiplicative_inverse(&self) -> Option<Self> {
+        // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 = x^-1 R.
+        // We use BigUints for now, since we don't care much about inverse performance.
         let self_biguint = u64_slice_to_biguint(&self.limbs);
         let order_biguint = u64_slice_to_biguint(&Self::ORDER);
-        let opt_inverse_biguint = inverse(self_biguint, &order_biguint);
+        let opt_inverse_biguint = modinv(self_biguint, order_biguint);
 
         opt_inverse_biguint.map(|inverse_biguint| Self {
-            limbs: biguint_to_u64_vec(inverse_biguint, 4).as_slice().try_into().unwrap()
+            limbs: Self::montgomery_multiply(
+                biguint_to_u64_vec(inverse_biguint, 4).as_slice().try_into().unwrap(),
+                Bls12Scalar::R3
+            )
         })
     }
 
@@ -201,11 +272,47 @@ impl Bls12Scalar {
 
         Bls12Scalar { limbs }
     }
-}
 
-impl From<u64> for Bls12Scalar {
-    fn from(n: u64) -> Self {
-        Bls12Scalar { limbs: [n, 0, 0, 0] }
+    #[unroll_for_loops]
+    fn montgomery_multiply(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+        // Interleaved Montgomery multiplication, as described in Algorithm 2 of
+        // https://eprint.iacr.org/2017/1057.pdf
+
+        // Note that in the loop below, to avoid explicitly shifting c, we will treat i as the least
+        // significant digit and wrap around.
+        let mut c = [0u64; 5];
+
+        for i in 0..4 {
+            // Add a[i] b to c.
+            let mut carry = 0;
+            for j in 0..4 {
+                let result = c[(i + j) % 5] as u128 + a[i] as u128 * b[j] as u128 + carry as u128;
+                c[(i + j) % 5] = result as u64;
+                carry = (result >> 64) as u64;
+            }
+            c[(i + 4) % 5] += carry;
+
+            // q = u c mod r = u c[0] mod r.
+            let q = Bls12Scalar::MU.wrapping_mul(c[i]);
+
+            // C += N q
+            carry = 0;
+            for j in 0..4 {
+                let result = c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
+                c[(i + j) % 5] = result as u64;
+                carry = (result >> 64) as u64;
+            }
+            c[(i + 4) % 5] += carry;
+
+            debug_assert_eq!(c[i], 0);
+        }
+
+        let mut result = [c[4], c[0], c[1], c[2]];
+        // Final conditional subtraction.
+        if cmp_4_4(result, Self::ORDER) != Ordering::Less {
+            result = sub_4_4(result, Self::ORDER);
+        }
+        result
     }
 }
 
@@ -253,10 +360,7 @@ impl Mul<Bls12Scalar> for Bls12Scalar {
     type Output = Bls12Scalar;
 
     fn mul(self, rhs: Bls12Scalar) -> Bls12Scalar {
-        // First we do a widening multiplication, then a modular reduction.
-        let product = mul_4_4(self.limbs, rhs.limbs);
-        let limbs = barrett_reduction_bls12_scalar(product);
-        Bls12Scalar { limbs }
+        Self { limbs: Self::montgomery_multiply(self.limbs, rhs.limbs) }
     }
 }
 
@@ -264,10 +368,7 @@ impl Mul<Bls12Base> for Bls12Base {
     type Output = Bls12Base;
 
     fn mul(self, rhs: Bls12Base) -> Bls12Base {
-        // First we do a widening multiplication, then a modular reduction.
-        let product = mul_6_6(self.limbs, rhs.limbs);
-        let limbs = barrett_reduction_bls12_base(product);
-        Bls12Base { limbs }
+        Self { limbs: Self::montgomery_multiply(self.limbs, rhs.limbs) }
     }
 }
 
@@ -317,55 +418,6 @@ impl Neg for Bls12Scalar {
             Bls12Scalar::ZERO
         } else {
             Bls12Scalar { limbs: sub_4_4(Bls12Scalar::ORDER, self.limbs) }
-        }
-    }
-}
-
-macro_rules! barrett_reduction {
-    (
-        $name:ident,
-        $n:expr,
-        $mul_n_n:ident,
-        $mul_2n_n:ident,
-        $cmp_n_plus_1_n:ident,
-        $sub_2n_2n:ident,
-        $sub_n_plus_1_n:ident,
-        $shl_3n_n:ident,
-        $modulus:expr,
-        $barrett_r:expr,
-        $barrett_k:expr
-    ) => {
-        #[unroll_for_loops]
-        fn $name(x: [u64; 2 * $n]) -> [u64; $n] {
-            // Then, to make it a modular multiplication, we apply the Barrett reduction algorithm.
-            // See https://www.nayuki.io/page/barrett-reduction-algorithm
-            let x_r = $mul_2n_n(x, $barrett_r);
-
-            // Shift left to divide by 4^k.
-            let mut x_r_shifted = $shl_3n_n(x_r, $barrett_k * 2);
-
-            let x_r_shifted_n = $mul_n_n(x_r_shifted, $modulus);
-            let t_2n = $sub_2n_2n(x, x_r_shifted_n);
-
-            // t should fit in m + 1 bits, where m is the modulus length in bits.
-            debug_assert!(t_2n[$n] == 0 || t_2n[$n] == 1,
-                          "t should fit in m + 1 bits: {:?}", t_2n);
-            for i in ($n + 1)..(2 * $n) {
-                debug_assert_eq!(t_2n[i], 0,
-                                 "t should fit in m + 1 bits: {:?}", t_2n);
-            }
-            // For efficiency, truncate t down to `$n + 1` `u64`s.
-            let t_n_plus_1: [u64; $n + 1] = (&t_2n[0..($n + 1)]).try_into().unwrap();
-
-            let result_n_plus_1 = if $cmp_n_plus_1_n(t_n_plus_1, $modulus) == Ordering::Less {
-                t_n_plus_1
-            } else {
-                $sub_n_plus_1_n(t_n_plus_1, $modulus)
-            };
-
-            // The difference should fit into 6 bits; truncate the most significant bit.
-            debug_assert_eq!(t_n_plus_1[$n], 0);
-            (&result_n_plus_1[0..$n]).try_into().unwrap()
         }
     }
 }
@@ -587,16 +639,12 @@ cmp_asymmetric!(cmp_7_6, 7, 6);
 shl!(shl_12_4, 12, 4);
 shl!(shl_18_6, 18, 6);
 
-barrett_reduction!(barrett_reduction_bls12_scalar, 4, mul_4_4, mul_8_4, cmp_5_4, sub_8_8, sub_5_4, shl_12_4,
-Bls12Scalar::ORDER, *BLS12_SCALAR_BARRETT_R, Bls12Scalar::BITS);
-barrett_reduction!(barrett_reduction_bls12_base, 6, mul_6_6, mul_12_6, cmp_7_6, sub_12_12, sub_7_6, shl_18_6,
-Bls12Base::ORDER, *BLS12_BASE_BARRETT_R, Bls12Base::BITS);
-
 #[cfg(test)]
 mod tests {
-    use crate::Bls12Scalar;
+    use num::{BigUint, FromPrimitive, One, Zero};
+
     use crate::conversions::u64_slice_to_biguint;
-    use crate::field::{Bls12Base, mul_12_6, mul_6_6};
+    use crate::field::{Bls12Base, Bls12Scalar, mul_12_6, mul_6_6};
 
     #[test]
     fn test_mul_6_6() {
@@ -618,18 +666,33 @@ mod tests {
     }
 
     #[test]
+    fn test_to_and_from_canonical() {
+        let a = [1, 2, 3, 4, 0, 0];
+        let a_biguint = u64_slice_to_biguint(&a);
+        let order_biguint = u64_slice_to_biguint(&Bls12Base::ORDER);
+        let r_biguint = u64_slice_to_biguint(&Bls12Base::R);
+
+        let a_blsbase = Bls12Base::from_canonical(a);
+        assert_eq!(u64_slice_to_biguint(&a_blsbase.limbs),
+                   &a_biguint * &r_biguint % &order_biguint);
+        assert_eq!(u64_slice_to_biguint(&a_blsbase.to_canonical()), a_biguint);
+    }
+
+    #[test]
     fn test_mul_bls12_base() {
         let a = [1, 2, 3, 4, 0, 0];
         let b = [3, 4, 5, 6, 0, 0];
 
-        let a_blsbase = Bls12Base { limbs: a };
-        let b_blsbase = Bls12Base { limbs: b };
         let a_biguint = u64_slice_to_biguint(&a);
         let b_biguint = u64_slice_to_biguint(&b);
         let order_biguint = u64_slice_to_biguint(&Bls12Base::ORDER);
+        let r_biguint = u64_slice_to_biguint(&Bls12Base::R);
+
+        let a_blsbase = Bls12Base::from_canonical(a);
+        let b_blsbase = Bls12Base::from_canonical(b);
 
         assert_eq!(
-            u64_slice_to_biguint(&(a_blsbase * b_blsbase).limbs),
+            u64_slice_to_biguint(&(a_blsbase * b_blsbase).to_canonical()),
             a_biguint * b_biguint % order_biguint);
     }
 
@@ -644,10 +707,10 @@ mod tests {
 
     #[test]
     fn exp() {
-        assert_eq!(Bls12Scalar::THREE.exp(Bls12Scalar::ZERO), Bls12Scalar::ONE);
-        assert_eq!(Bls12Scalar::THREE.exp(Bls12Scalar::ONE), Bls12Scalar::THREE);
-        assert_eq!(Bls12Scalar::THREE.exp(Bls12Scalar::TWO), Bls12Scalar::from(9u64));
-        assert_eq!(Bls12Scalar::THREE.exp(Bls12Scalar::THREE), Bls12Scalar::from(27u64));
+        assert_eq!(Bls12Scalar::THREE.exp(BigUint::zero()), Bls12Scalar::ONE);
+        assert_eq!(Bls12Scalar::THREE.exp(BigUint::one()), Bls12Scalar::THREE);
+        assert_eq!(Bls12Scalar::THREE.exp(BigUint::from_u8(2).unwrap()), Bls12Scalar::from_canonical_u64(9));
+        assert_eq!(Bls12Scalar::THREE.exp(BigUint::from_u8(3).unwrap()), Bls12Scalar::from_canonical_u64(27));
     }
 
     #[test]
@@ -656,10 +719,10 @@ mod tests {
             let n = 1 << n_power as u64;
             let root = Bls12Scalar::primitive_root_of_unity(n_power);
 
-            assert_eq!(root.exp(Bls12Scalar::from(n)), Bls12Scalar::ONE);
+            assert_eq!(root.exp(BigUint::from_u64(n).unwrap()), Bls12Scalar::ONE);
 
             if n > 1 {
-                assert_ne!(root.exp(Bls12Scalar::from(n - 1)), Bls12Scalar::ONE)
+                assert_ne!(root.exp(BigUint::from_u64(n - 1).unwrap()), Bls12Scalar::ONE)
             }
         }
     }


### PR DESCRIPTION
This makes field multiplications almost 3x faster.