### PR TITLE
Adding ZETA for endomorphism on Tweedle curves.

### DIFF
--- a/src/curve.rs
+++ b/src/curve.rs
@@ -24,6 +24,7 @@ pub trait Curve: 'static + Sized + Copy {
 /// where `phi(P) = [zeta_q] P` for some `zeta_q` of multiplicative order 3.
 pub trait HaloEndomorphismCurve: Curve {
     const ZETA: Self::BaseField;
+    const ZETA_SCALAR: Self::ScalarField;
 }
 
 /// A point on a short Weierstrass curve, represented in affine coordinates.

--- a/src/tweedledee_curve.rs
+++ b/src/tweedledee_curve.rs
@@ -8,7 +8,7 @@ impl Curve for Tweedledee {
     type ScalarField = TweedledumBase;
 
     const A: TweedledeeBase = TweedledeeBase::ZERO;
-    const B: TweedledeeBase = TweedledeeBase::ONE;
+    const B: TweedledeeBase = TweedledeeBase::FIVE;
 
     const GENERATOR_AFFINE: AffinePoint<Self> = AffinePoint {
         x: TweedledeeBase::NEG_ONE,
@@ -18,6 +18,59 @@ impl Curve for Tweedledee {
 }
 
 impl HaloEndomorphismCurve for Tweedledee {
-    // TODO: Configure zeta
-    const ZETA: Self::BaseField = TweedledeeBase::ZERO;
+    const ZETA: Self::BaseField = TweedledeeBase {
+        limbs: [
+            1444470991491022206,
+            3301226169728360777,
+            72516509137424193,
+            708688398506307241,
+        ],
+    };
+    const ZETA_SCALAR: Self::ScalarField = TweedledumBase {
+        limbs: [
+            13597504620482004229,
+            16590497220115833568,
+            15137822970486674306,
+            1901757351910266741,
+        ],
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::{AffinePoint, Curve, HaloEndomorphismCurve, ProjectivePoint};
+    use crate::Tweedledee;
+
+    /// A simple, somewhat inefficient implementation of multiplication which is used as a reference
+    /// for correctness.
+    fn mul_naive(
+        lhs: <Tweedledee as Curve>::ScalarField,
+        rhs: ProjectivePoint<Tweedledee>,
+    ) -> ProjectivePoint<Tweedledee> {
+        let mut g = rhs;
+        let mut sum = ProjectivePoint::ZERO;
+        for limb in lhs.to_canonical().iter() {
+            for j in 0..64 {
+                if (limb >> j & 1u64) != 0u64 {
+                    sum = sum + g;
+                }
+                g = g.double();
+            }
+        }
+        sum
+    }
+
+    #[test]
+    fn test_endomorphism_tweedledee() {
+        let g = Tweedledee::GENERATOR_AFFINE;
+        let h = AffinePoint::<Tweedledee> {
+            x: g.x * Tweedledee::ZETA,
+            y: g.y,
+            zero: false,
+        };
+        assert_eq!(
+            h,
+            mul_naive(Tweedledee::ZETA_SCALAR, g.to_projective()).to_affine()
+        );
+    }
 }

--- a/src/tweedledum_curve.rs
+++ b/src/tweedledum_curve.rs
@@ -8,6 +8,7 @@ impl Curve for Tweedledum {
     type ScalarField = TweedledeeBase;
 
     const A: TweedledumBase = TweedledumBase::ZERO;
+    // B = 7
     const B: TweedledumBase = TweedledumBase {
         limbs: [
             18317648394857742309,

--- a/src/tweedledum_curve.rs
+++ b/src/tweedledum_curve.rs
@@ -8,16 +8,84 @@ impl Curve for Tweedledum {
     type ScalarField = TweedledeeBase;
 
     const A: TweedledumBase = TweedledumBase::ZERO;
-    const B: TweedledumBase = TweedledumBase::ONE;
+    const B: TweedledumBase = TweedledumBase {
+        limbs: [
+            18317648394857742309,
+            11556519044732520811,
+            18446744073709551615,
+            4611686018427387903,
+        ]
+    };
 
     const GENERATOR_AFFINE: AffinePoint<Self> = AffinePoint {
-        x: TweedledumBase::NEG_ONE,
-        y: TweedledumBase::TWO,
+        x: TweedledumBase::ONE,
+        y: TweedledumBase {
+            limbs: [
+                12815994359195135157,
+                12442237869110527732,
+                9256472484777506843,
+                1114242145010923164,
+            ]
+        },
         zero: false,
     };
 }
 
 impl HaloEndomorphismCurve for Tweedledum {
-    // TODO: Configure zeta
-    const ZETA: Self::BaseField = TweedledumBase::ZERO;
+    const ZETA: Self::BaseField = TweedledumBase {
+        limbs: [
+            7605997034305223424,
+            3132214451552427455,
+            3308921103222877309,
+            2709928666517121162,
+        ]
+    };
+    const ZETA_SCALAR: Self::ScalarField = TweedledeeBase {
+        limbs: [
+            9282944046338294407,
+            16421485501699768486,
+            18374227564572127422,
+            3902997619921080662,
+        ]
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::{AffinePoint, Curve, HaloEndomorphismCurve, ProjectivePoint};
+    use crate::Tweedledum;
+
+    /// A simple, somewhat inefficient implementation of multiplication which is used as a reference
+    /// for correctness.
+    fn mul_naive(
+        lhs: <Tweedledum as Curve>::ScalarField,
+        rhs: ProjectivePoint<Tweedledum>,
+    ) -> ProjectivePoint<Tweedledum> {
+        let mut g = rhs;
+        let mut sum = ProjectivePoint::ZERO;
+        for limb in lhs.to_canonical().iter() {
+            for j in 0..64 {
+                if (limb >> j & 1u64) != 0u64 {
+                    sum = sum + g;
+                }
+                g = g.double();
+            }
+        }
+        sum
+    }
+
+    #[test]
+    fn test_endomorphism_tweedledum() {
+        let g = Tweedledum::GENERATOR_AFFINE;
+        assert!(g.is_valid());
+        let h = AffinePoint::<Tweedledum> {
+            x: g.x * Tweedledum::ZETA,
+            y: g.y,
+            zero: false,
+        };
+        assert_eq!(
+            h,
+            mul_naive(Tweedledum::ZETA_SCALAR, g.to_projective()).to_affine()
+        );
+    }
 }


### PR DESCRIPTION
I added ZETA for the Tweedledee and Tweedledum curves, along with tests verifying that the endomorphism works. 
Here is the Sage code used to generate the ZETA values:
```python
# Returns (zetta_base, zeta_scalar) such that (zetta_base*x,y) = zetta_scalar*(x,y) on the curve y^2 = x**3 + b over GF(q).
def get_zetta(q, b):
    E = EllipticCurve(GF(q), [0, b])
    r = E.order()
    assert(is_prime(r))
    K.<x> = GF(q)[]
    Kr.<xr> = GF(r)[]
    zettas_base = [a[0] for a in (x^2 + x + 1).roots()]
    zettas_scalar = [a[0] for a in (xr^2 + xr + 1).roots()]
    zetta_scalar = zettas_scalar[0]
    G = E.random_point()
    for a in zettas_base:
        if ZZ(zetta_scalar)*G == E(a*G.xy()[0], G.xy()[1]):
            return ZZ(a), ZZ(zetta_scalar)

q = 28948022309329048855892746252171976963322203655955319056773317069363642105857
b = 5

z_b, z_s = get_zetta(q, b)
E = EllipticCurve(GF(q), [0, b])
G = E.random_point()
assert(z_s * G == E(z_b * G.xy()[0], G.xy()[1])) 
```