### PR TITLE
Misc prover fixes to get William's test working

### DIFF
--- a/src/curve_msm.rs
+++ b/src/curve_msm.rs
@@ -132,7 +132,7 @@ pub fn msm_execute_parallel<C: Curve>(
             affine_multisummation_best(summations)
         })
         .collect();
-    println!("Computing the per-digit summations (in parallel) took {}s", start.elapsed().as_secs_f64());
+    // println!("Computing the per-digit summations (in parallel) took {}s", start.elapsed().as_secs_f64());
 
     let start = Instant::now();
     let mut y = ProjectivePoint::ZERO;
@@ -141,7 +141,7 @@ pub fn msm_execute_parallel<C: Curve>(
         u = u + digit_acc[digit];
         y = y + u;
     }
-    println!("Final summation (sequential) {}s", start.elapsed().as_secs_f64());
+    // println!("Final summation (sequential) {}s", start.elapsed().as_secs_f64());
     y
 }
 

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -90,6 +90,9 @@ pub fn fft_with_precomputation_power_of_2<F: Field>(
     coefficients: &[F],
     precomputation: &FftPrecomputation<F>,
 ) -> Vec<F> {
+    debug_assert_eq!(coefficients.len(), precomputation.subgroups_rev.last().unwrap().len(),
+                     "Number of coefficients does not match size of subgroup in precomputation");
+
     let degree = coefficients.len();
     let half_degree = coefficients.len() >> 1;
     let degree_pow = log2_strict(degree);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,21 @@ const SECURITY_BITS: usize = 128;
 
 fn main() {
     println!("Generating inner circuit");
+    let start = Instant::now();
     let inner_circuit = generate_trivial_circuit();
+    println!("Finished in {}s", start.elapsed().as_secs_f64());
     println!();
 
     println!("Generating inner witness");
+    let start = Instant::now();
     let inner_witness = inner_circuit.generate_witness(PartialWitness::new());
+    println!("Finished in {}s", start.elapsed().as_secs_f64());
     println!();
 
     println!("Generating inner proof");
+    let start = Instant::now();
     let inner_proof = inner_circuit.generate_proof::<Tweedledee>(inner_witness).unwrap();
+    println!("Finished in {}s", start.elapsed().as_secs_f64());
     println!();
 
     println!("Generating recursion circuit...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use plonky::{recursive_verification_circuit, Tweedledum, Tweedledee, PartialWitness, Curve, Circuit, CircuitBuilder, BufferGate};
+use plonky::{recursive_verification_circuit, Tweedledum, Tweedledee, PartialWitness, Circuit, CircuitBuilder, BufferGate};
 
 const INNER_PROOF_DEGREE_POW: usize = 14;
 const INNER_PROOF_DEGREE: usize = 1 << INNER_PROOF_DEGREE_POW;

--- a/src/plonk_recursion.rs
+++ b/src/plonk_recursion.rs
@@ -1,4 +1,4 @@
-use crate::{AffinePointTarget, Circuit, CircuitBuilder, Curve, CurveMulOp, Field, get_subgroup_shift, HaloCurve, NUM_CONSTANTS, NUM_ROUTED_WIRES, NUM_WIRES, OpeningSetTarget, ProofTarget, PublicInput, QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER, Target};
+use crate::{AffinePointTarget, Circuit, CircuitBuilder, CurveMulOp, Field, get_subgroup_shift, HaloCurve, NUM_CONSTANTS, NUM_ROUTED_WIRES, NUM_WIRES, OpeningSetTarget, ProofTarget, PublicInput, QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER, Target};
 use crate::plonk_challenger::RecursiveChallenger;
 use crate::plonk_gates::evaluate_all_constraints_recursively;
 use crate::plonk_util::{powers_recursive, reduce_with_powers_recursive};


### PR DESCRIPTION
- Add a `ConstantGate` which copies a constant to one of its wires. We were using `BufferGate` for this earlier, but `add_blinding_gate` expected `BufferGate` to be a no-op (i.e. enforce no constraints).
- Add a few assertions to catch errors earlier with more helpful errors
- Misc small fixes, like indices being in the wrong order