### PR TITLE
Add tests for low-degreeness of each constraint

### DIFF
--- a/src/plonk_gates.rs
+++ b/src/plonk_gates.rs
@@ -1408,10 +1408,10 @@ macro_rules! test_gate_low_degree {
 
             // Make sure each extended polynomial is still degree n.
             for values_8n in &constant_values_8n {
-                assert_eq!($crate::plonk_util::polynomial_degree(values_8n, &fft_precomputation_8n), n);
+                assert_eq!($crate::plonk_util::polynomial_degree(values_8n, &fft_precomputation_8n), n - 1);
             }
             for values_8n in &wire_values_8n {
-                assert_eq!($crate::plonk_util::polynomial_degree(values_8n, &fft_precomputation_8n), n);
+                assert_eq!($crate::plonk_util::polynomial_degree(values_8n, &fft_precomputation_8n), n - 1);
             }
 
             let constant_values_8n_t = $crate::util::transpose(&constant_values_8n);
@@ -1438,7 +1438,7 @@ macro_rules! test_gate_low_degree {
                 .map(|c| $crate::plonk_util::polynomial_degree(c, &fft_precomputation_8n))
                 .collect::<Vec<_>>();
             for (i, &deg) in constraint_degrees.iter().enumerate() {
-                assert!(deg <= 8 * n, "{}'th constraint's degree exceeds 8n: {}", i, deg);
+                assert!(deg < 8 * n, "{}'th constraint's degree is >=8n: {}", i, deg);
             }
         }
     };

--- a/src/plonk_gates.rs
+++ b/src/plonk_gates.rs
@@ -1387,6 +1387,7 @@ macro_rules! test_gate_low_degree {
             let n = 1024;
             let fft_precomputation_n = $crate::fft::fft_precompute::<SF>(n);
             let fft_precomputation_8n = $crate::fft::fft_precompute::<SF>(8 * n);
+            let fft_precomputation_16n = $crate::fft::fft_precompute::<SF>(16 * n);
 
             // Generate random constant and wire polynomials.
             let mut constant_values_n: Vec<Vec<SF>> = vec![Vec::new(); $crate::plonk::NUM_CONSTANTS];
@@ -1400,45 +1401,57 @@ macro_rules! test_gate_low_degree {
                 }
             }
 
-            // Low-degree extend them to 8n values.
-            let constant_coeffs_n = $crate::plonk_util::values_to_coeffs(&constant_values_n, &fft_precomputation_n);
-            let constant_values_8n = $crate::plonk_util::coeffs_to_values_padded(&constant_coeffs_n, &fft_precomputation_8n);
-            let wire_coeffs_n = $crate::plonk_util::values_to_coeffs(&wire_values_n, &fft_precomputation_n);
-            let wire_values_8n = $crate::plonk_util::coeffs_to_values_padded(&wire_coeffs_n, &fft_precomputation_8n);
+            // Low-degree extend them to 16n values.
+            let mut constant_coeffs_16n = $crate::plonk_util::values_to_coeffs(&constant_values_n, &fft_precomputation_n);
+            let mut wire_coeffs_16n = $crate::plonk_util::values_to_coeffs(&wire_values_n, &fft_precomputation_n);
+            for coeffs in constant_coeffs_16n.iter_mut().chain(wire_coeffs_16n.iter_mut()) {
+                while coeffs.len() < 16 * n {
+                    coeffs.push(<SF as $crate::field::Field>::ZERO);
+                }
+            }
+            let constant_values_16n: Vec<Vec<SF>> = constant_coeffs_16n.iter()
+                .map(|coeffs| $crate::fft::fft_with_precomputation_power_of_2(coeffs, &fft_precomputation_16n))
+                .collect();
+            let wire_values_16n: Vec<Vec<SF>> = wire_coeffs_16n.iter()
+                .map(|coeffs| $crate::fft::fft_with_precomputation_power_of_2(coeffs, &fft_precomputation_16n))
+                .collect();
 
             // Make sure each extended polynomial is still degree n.
-            for values_8n in &constant_values_8n {
-                assert_eq!($crate::plonk_util::polynomial_degree(values_8n, &fft_precomputation_8n), n - 1);
-            }
-            for values_8n in &wire_values_8n {
-                assert_eq!($crate::plonk_util::polynomial_degree(values_8n, &fft_precomputation_8n), n - 1);
+            for values_16n in constant_values_16n.iter().chain(wire_values_16n.iter()) {
+                assert!($crate::plonk_util::polynomial_degree(values_16n, &fft_precomputation_16n) < n);
             }
 
-            let constant_values_8n_t = $crate::util::transpose(&constant_values_8n);
-            let wire_values_8n_t = $crate::util::transpose(&wire_values_8n);
+            let constant_values_16n_t = $crate::util::transpose(&constant_values_16n);
+            let wire_values_16n_t = $crate::util::transpose(&wire_values_16n);
 
-            // Evaluate constraints at each of our 8n points.
-            let mut constraint_values_8n: Vec<Vec<SF>> = Vec::new();
-            for i in 0..8 * n {
+            // Evaluate constraints at each of our 16n points.
+            let mut constraint_values_16n: Vec<Vec<SF>> = Vec::new();
+            for i in 0..16 * n {
                 let constraints: Vec<SF> = <$gate as $crate::plonk_gates::Gate<C>>::evaluate_filtered(
-                    &constant_values_8n_t[i],
-                    &wire_values_8n_t[i],
-                    &wire_values_8n_t[(i + 8) % (8 * n)],
-                    &wire_values_8n_t[(i + 8 * $crate::plonk::GRID_WIDTH) % (8 * n)]);
+                    &constant_values_16n_t[i],
+                    &wire_values_16n_t[i],
+                    &wire_values_16n_t[(i + 16) % (16 * n)],
+                    &wire_values_16n_t[(i + 16 * $crate::plonk::GRID_WIDTH) % (16 * n)]);
                 for (j, &c) in constraints.iter().enumerate() {
-                    while constraint_values_8n.len() <= j {
-                        constraint_values_8n.push(Vec::new());
+                    if constraint_values_16n.len() <= j {
+                        constraint_values_16n.push(Vec::new());
                     }
-                    constraint_values_8n[j].push(c);
+                    constraint_values_16n[j].push(c);
                 }
             }
 
-            // Check that the degree of each constraint is within 8n.
-            let constraint_degrees = constraint_values_8n.iter()
-                .map(|c| $crate::plonk_util::polynomial_degree(c, &fft_precomputation_8n))
+            // Check that the degree of each constraint is within the limit.
+            let constraint_degrees = constraint_values_16n.iter()
+                .map(|c| $crate::plonk_util::polynomial_degree(c, &fft_precomputation_16n))
                 .collect::<Vec<_>>();
+            let max_degree_excl = (crate::plonk::QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER + 1) * n;
             for (i, &deg) in constraint_degrees.iter().enumerate() {
-                assert!(deg < 8 * n, "{}'th constraint's degree is >=8n: {}", i, deg);
+                assert!(deg < max_degree_excl,
+                "Constraint at index {} has degree {}; should be less than {}n = {}",
+                i,
+                deg,
+                crate::plonk::QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER + 1,
+                max_degree_excl);
             }
         }
     };

--- a/src/plonk_util.rs
+++ b/src/plonk_util.rs
@@ -244,6 +244,14 @@ pub fn sigma_polynomials<F: Field>(
         .collect()
 }
 
+pub(crate) fn polynomial_degree<F: Field>(
+    points: &[F],
+    fft_precomputation: &FftPrecomputation<F>,
+) -> usize {
+    let coeffs = ifft_with_precomputation_power_of_2(&points, fft_precomputation);
+    coeffs.iter().rev().skip_while(|c| c.is_zero()).count()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/plonk_util.rs
+++ b/src/plonk_util.rs
@@ -249,7 +249,7 @@ pub(crate) fn polynomial_degree<F: Field>(
     fft_precomputation: &FftPrecomputation<F>,
 ) -> usize {
     let coeffs = ifft_with_precomputation_power_of_2(&points, fft_precomputation);
-    coeffs.iter().rev().skip_while(|c| c.is_zero()).count()
+    coeffs.iter().rev().skip_while(|c| c.is_zero()).count() - 1
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I `#[ignore]`d the tests since they're expensive, but they can be run like this:

    cargo test low_degree -- --ignored