### PR TITLE
Derive public inputs in a generic way

### DIFF
--- a/src/bin/recursion.rs
+++ b/src/bin/recursion.rs
@@ -95,8 +95,7 @@ fn main() -> Result<()> {
 
     println!("Verifying proof...");
     let start = Instant::now();
-    let pis =
-        RecursionPublicInputs::proof_to_public_inputs::<Tweedledum, Tweedledee>(&inner_proof, &[])?;
+    let pis = proof.get_public_inputs(recursion_circuit.circuit.num_public_inputs);
     println!("Number of public inputs: {}", recursion_circuit.circuit.num_public_inputs);
     verify_proof_circuit::<Tweedledee, Tweedledum>(
         &pis,

--- a/src/plonk_proof.rs
+++ b/src/plonk_proof.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, ensure, Result};
 
 use crate::plonk_challenger::Challenger;
 use crate::plonk_util::{halo_g, halo_s, pedersen_hash};
-use crate::{AffinePoint, AffinePointTarget, Curve, Field, MsmPrecomputation, PartialWitness, Target, SECURITY_BITS};
+use crate::{AffinePoint, AffinePointTarget, Curve, Field, MsmPrecomputation, PartialWitness, Target, SECURITY_BITS, NUM_WIRES};
 
 #[derive(Debug, Clone, Copy)]
 pub struct SchnorrProof<C: Curve> {
@@ -46,6 +46,14 @@ pub struct Proof<C: Curve> {
 }
 
 impl<C: Curve> Proof<C> {
+    pub fn get_public_inputs(&self, count: usize) -> Vec<C::ScalarField> {
+        (0..count).map(|i| {
+            let pi_gate_idx = i / NUM_WIRES;
+            let wire_idx = i % NUM_WIRES;
+            self.o_public_inputs[pi_gate_idx].o_wires[wire_idx]
+        }).collect()
+    }
+
     pub fn all_opening_sets(&self) -> Vec<OpeningSet<C::ScalarField>> {
         [
             self.o_public_inputs.as_slice(),

--- a/src/plonk_recursion.rs
+++ b/src/plonk_recursion.rs
@@ -103,45 +103,6 @@ impl RecursionPublicInputs {
 
         Ok(())
     }
-
-    pub fn proof_to_public_inputs<C: Curve, InnerC: HaloCurve<BaseField = C::ScalarField>>(
-        proof: &Proof<C>,
-        old_proofs: &[OldProof<InnerC>],
-    ) -> Result<Vec<C::BaseField>> {
-        let challs = proof.get_challenges()?;
-        let mut pis = [
-            C::ScalarField::try_convert_all::<C::BaseField>(&[
-                challs.beta,
-                challs.gamma,
-                challs.alpha,
-                challs.zeta,
-            ])?
-            .as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(&proof.o_local.o_constants)?.as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(&proof.o_local.o_plonk_sigmas)?
-                .as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(&proof.o_local.o_wires)?.as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(&proof.o_right.o_wires)?.as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(&proof.o_below.o_wires)?.as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(&[
-                proof.o_local.o_plonk_z,
-                proof.o_right.o_plonk_z,
-            ])?
-            .as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(&proof.o_local.o_plonk_t)?.as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(&challs.ipa_challenges)?.as_slice(),
-            C::ScalarField::try_convert_all::<C::BaseField>(
-                &C::ScalarField::batch_multiplicative_inverse(&challs.ipa_challenges),
-            )?
-            .as_slice(),
-        ]
-        .concat();
-        for p in old_proofs {
-            pis.push(C::ScalarField::try_convert::<C::BaseField>(&p.halo_g.x)?);
-            pis.push(C::ScalarField::try_convert::<C::BaseField>(&p.halo_g.y)?);
-        }
-        Ok(pis)
-    }
 }
 
 /// The number of `PublicInputGate`s needed to route the given number of public inputs.


### PR DESCRIPTION
`proof_to_public_inputs` isn't really needed since these values are also derived by the circuit (from the inputs given by `ProofTarget::populate_witness` and `OldProofTarget::populate_witness`). Arguably the redundancy could be useful for catching some errors, but I'd prefer to minimize redundancy to keep the code simpler.