### PR TITLE
Modify Challenger to use a duplex sponge pattern

### DIFF
--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -103,6 +103,10 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         }
     }
 
+    pub fn constant_wires(&mut self, constants: &[C::ScalarField]) -> Vec<Target> {
+        constants.iter().map(|&c| self.constant_wire(c)).collect()
+    }
+
     pub fn constant_wire_u32(&mut self, c: u32) -> Target {
         self.constant_wire(C::ScalarField::from_canonical_u32(c))
     }

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -41,6 +41,7 @@ mod rescue_a;
 mod rescue_b;
 
 pub const RESCUE_SPONGE_WIDTH: usize = 4;
+pub const RESCUE_SPONGE_RATE: usize = RESCUE_SPONGE_WIDTH - 1;
 
 pub fn evaluate_all_constraints<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>>(
     local_constant_values: &[C::ScalarField],

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -552,10 +552,13 @@ impl<C: HaloCurve> Circuit<C> {
         }
     }
 
-    pub fn generate_witness(
+    /// Generates a `PartialWitness`, which maps `Target`s to their values. Although
+    /// `PartialWitness` is designed as a sparse representation, the result here should have an
+    /// entry for every target in the circuit.
+    pub fn generate_partial_witness(
         &self,
         inputs: PartialWitness<C::ScalarField>,
-    ) -> Witness<C::ScalarField> {
+    ) -> PartialWitness<C::ScalarField> {
         let start = Instant::now();
 
         // Index generator indices by their dependencies.
@@ -639,7 +642,15 @@ impl<C: HaloCurve> Circuit<C> {
         // );
 
         println!("Witness generation took {}s", start.elapsed().as_secs_f32());
-        Witness::from_partial(&witness, self.degree())
+        witness
+    }
+
+    pub fn generate_witness(
+        &self,
+        inputs: PartialWitness<C::ScalarField>,
+    ) -> Witness<C::ScalarField> {
+        let partial_witness = self.generate_partial_witness(inputs);
+        Witness::from_partial(&partial_witness, self.degree())
     }
 
     /// For the given set of targets, find any copy constraints involving those targets and populate

--- a/src/plonk_challenger.rs
+++ b/src/plonk_challenger.rs
@@ -108,12 +108,6 @@ impl<F: Field> Challenger<F> {
     /// Absorb any buffered inputs. After calling this, the input buffer will be empty.
     fn absorb_buffered_inputs(&mut self) {
         for input_chunk in self.input_buffer.chunks(RESCUE_SPONGE_RATE) {
-            // If this is a partial chunk, zero-pad it.
-            let mut input_chunk = input_chunk.to_vec();
-            while input_chunk.len() < RESCUE_SPONGE_RATE {
-                input_chunk.push(F::ZERO);
-            }
-
             // Add the inputs to our sponge state.
             for (i, &input) in input_chunk.iter().enumerate() {
                 self.sponge_state[i] = self.sponge_state[i] + input;
@@ -204,12 +198,6 @@ impl<C: HaloCurve> RecursiveChallenger<C> {
     /// Absorb any buffered inputs. After calling this, the input buffer will be empty.
     fn absorb_buffered_inputs(&mut self, builder: &mut CircuitBuilder<C>) {
         for input_chunk in self.input_buffer.chunks(RESCUE_SPONGE_RATE) {
-            // If this is a partial chunk, zero-pad it.
-            let mut input_chunk = input_chunk.to_vec();
-            while input_chunk.len() < RESCUE_SPONGE_RATE {
-                input_chunk.push(builder.zero_wire());
-            }
-
             // Add the inputs to our sponge state.
             for (i, &input) in input_chunk.iter().enumerate() {
                 self.sponge_state[i] = builder.add(self.sponge_state[i], input);

--- a/src/plonk_challenger.rs
+++ b/src/plonk_challenger.rs
@@ -1,24 +1,39 @@
 use std::marker::PhantomData;
 
-use crate::{rescue_sponge, AffinePoint, AffinePointTarget, CircuitBuilder, Curve, Field, HaloCurve, ProjectivePoint, Target};
+use crate::{AffinePoint, AffinePointTarget, CircuitBuilder, Curve, Field, HaloCurve, ProjectivePoint, rescue_permutation, RESCUE_SPONGE_RATE, RESCUE_SPONGE_WIDTH, Target};
 
 /// Observes prover messages, and generates challenges by hashing the transcript.
 #[derive(Clone)]
 pub(crate) struct Challenger<F: Field> {
-    transcript: Vec<F>,
+    sponge_state: Vec<F>,
+    input_buffer: Vec<F>,
+    output_buffer: Vec<F>,
     security_bits: usize,
 }
 
+/// Observes prover messages, and generates verifier challenges based on the transcript.
+///
+/// The implementation is roughly based on a duplex sponge with a Rescue permutation. Note that in
+/// each round, our sponge can absorb an arbitrary number of prover messages and generate an
+/// arbitrary number of verifier challenges. This might appear to diverge from the duplex sponge
+/// design, but it can be viewed as a duplex sponge whose inputs are sometimes zero (when we perform
+/// multiple squeezes) and whose outputs are sometimes ignored (when we perform multiple
+/// absorptions). Thus the security properties of a duplex sponge still apply to our design.
 impl<F: Field> Challenger<F> {
     pub(crate) fn new(security_bits: usize) -> Challenger<F> {
         Challenger {
-            transcript: Vec::new(),
+            sponge_state: vec![F::ZERO; RESCUE_SPONGE_WIDTH],
+            input_buffer: Vec::new(),
+            output_buffer: Vec::new(),
             security_bits,
         }
     }
 
     pub(crate) fn observe_element(&mut self, element: F) {
-        self.transcript.push(element);
+        // Any buffered outputs are now invalid, since they wouldn't reflect this input.
+        self.output_buffer.clear();
+
+        self.input_buffer.push(element);
     }
 
     pub(crate) fn observe_elements(&mut self, elements: &[F]) {
@@ -28,8 +43,7 @@ impl<F: Field> Challenger<F> {
     }
 
     pub(crate) fn observe_affine_point<C: Curve<BaseField = F>>(&mut self, point: AffinePoint<C>) {
-        // TODO: Uncomment this.
-        // debug_assert!(!point.zero);
+        debug_assert!(!point.zero);
         self.observe_element(point.x);
         self.observe_element(point.y);
     }
@@ -68,42 +82,75 @@ impl<F: Field> Challenger<F> {
     }
 
     pub(crate) fn get_challenge(&mut self) -> F {
-        self.get_n_challenges(1)[0]
+        self.absorb_buffered_inputs();
+
+        if self.output_buffer.is_empty() {
+            // Evaluate the permutation to produce `r` new outputs.
+            self.sponge_state = rescue_permutation(&self.sponge_state, self.security_bits);
+            self.output_buffer = self.sponge_state[0..RESCUE_SPONGE_RATE].to_vec();
+        }
+
+        self.output_buffer.pop().expect("Output buffer should be non-empty")
     }
 
     pub(crate) fn get_2_challenges(&mut self) -> (F, F) {
-        let challenges = self.get_n_challenges(2);
-        (challenges[0], challenges[1])
+        (self.get_challenge(), self.get_challenge())
     }
 
     pub(crate) fn get_3_challenges(&mut self) -> (F, F, F) {
-        let challenges = self.get_n_challenges(3);
-        (challenges[0], challenges[1], challenges[2])
+        (self.get_challenge(), self.get_challenge(), self.get_challenge())
     }
 
     pub(crate) fn get_n_challenges(&mut self, n: usize) -> Vec<F> {
-        let challenges = rescue_sponge(self.transcript.clone(), n, self.security_bits);
-        self.transcript = vec![challenges[0]];
-        challenges
+        (0..n).map(|_| self.get_challenge()).collect()
+    }
+
+    /// Absorb any buffered inputs. After calling this, the input buffer will be empty.
+    fn absorb_buffered_inputs(&mut self) {
+        for input_chunk in self.input_buffer.chunks(RESCUE_SPONGE_RATE) {
+            // If this is a partial chunk, zero-pad it.
+            let mut input_chunk = input_chunk.to_vec();
+            while input_chunk.len() < RESCUE_SPONGE_RATE {
+                input_chunk.push(F::ZERO);
+            }
+
+            // Add the inputs to our sponge state.
+            for (i, &input) in input_chunk.iter().enumerate() {
+                self.sponge_state[i] = self.sponge_state[i] + input;
+            }
+
+            // Apply the permutation.
+            self.sponge_state = rescue_permutation(&self.sponge_state, self.security_bits);
+        }
+
+        self.input_buffer.clear();
     }
 }
 
-/// Observes prover messages, and generates challenges by hashing the transcript.
+/// A recursive version of `Challenger`.
 pub(crate) struct RecursiveChallenger<C: HaloCurve> {
-    transcript: Vec<Target>,
+    sponge_state: Vec<Target>,
+    input_buffer: Vec<Target>,
+    output_buffer: Vec<Target>,
     _phantom: PhantomData<C>,
 }
 
 impl<C: HaloCurve> RecursiveChallenger<C> {
-    pub(crate) fn new() -> RecursiveChallenger<C> {
+    pub(crate) fn new(builder: &mut CircuitBuilder<C>) -> RecursiveChallenger<C> {
+        let zero = builder.zero_wire();
         RecursiveChallenger {
-            transcript: Vec::new(),
+            sponge_state: vec![zero; RESCUE_SPONGE_WIDTH],
+            input_buffer: Vec::new(),
+            output_buffer: Vec::new(),
             _phantom: PhantomData,
         }
     }
 
     pub(crate) fn observe_element(&mut self, target: Target) {
-        self.transcript.push(target);
+        // Any buffered outputs are now invalid, since they wouldn't reflect this input.
+        self.output_buffer.clear();
+
+        self.input_buffer.push(target);
     }
 
     pub(crate) fn observe_elements(&mut self, targets: &[Target]) {
@@ -124,20 +171,26 @@ impl<C: HaloCurve> RecursiveChallenger<C> {
     }
 
     pub(crate) fn get_challenge(&mut self, builder: &mut CircuitBuilder<C>) -> Target {
-        self.get_n_challenges(builder, 1)[0]
+        self.absorb_buffered_inputs(builder);
+
+        if self.output_buffer.is_empty() {
+            // Evaluate the permutation to produce `r` new outputs.
+            self.sponge_state = builder.rescue_permutation(&self.sponge_state);
+            self.output_buffer = self.sponge_state[0..RESCUE_SPONGE_RATE].to_vec();
+        }
+
+        self.output_buffer.pop().expect("Output buffer should be non-empty")
     }
 
     pub(crate) fn get_2_challenges(&mut self, builder: &mut CircuitBuilder<C>) -> (Target, Target) {
-        let challenges = self.get_n_challenges(builder, 2);
-        (challenges[0], challenges[1])
+        (self.get_challenge(builder), self.get_challenge(builder))
     }
 
     pub(crate) fn get_3_challenges(
         &mut self,
         builder: &mut CircuitBuilder<C>,
     ) -> (Target, Target, Target) {
-        let challenges = self.get_n_challenges(builder, 3);
-        (challenges[0], challenges[1], challenges[2])
+        (self.get_challenge(builder), self.get_challenge(builder), self.get_challenge(builder))
     }
 
     pub(crate) fn get_n_challenges(
@@ -145,8 +198,74 @@ impl<C: HaloCurve> RecursiveChallenger<C> {
         builder: &mut CircuitBuilder<C>,
         n: usize,
     ) -> Vec<Target> {
-        let challenges = builder.rescue_sponge(&self.transcript, n);
-        self.transcript = vec![challenges[0]];
-        challenges
+        (0..n).map(|_| self.get_challenge(builder)).collect()
+    }
+
+    /// Absorb any buffered inputs. After calling this, the input buffer will be empty.
+    fn absorb_buffered_inputs(&mut self, builder: &mut CircuitBuilder<C>) {
+        for input_chunk in self.input_buffer.chunks(RESCUE_SPONGE_RATE) {
+            // If this is a partial chunk, zero-pad it.
+            let mut input_chunk = input_chunk.to_vec();
+            while input_chunk.len() < RESCUE_SPONGE_RATE {
+                input_chunk.push(builder.zero_wire());
+            }
+
+            // Add the inputs to our sponge state.
+            for (i, &input) in input_chunk.iter().enumerate() {
+                self.sponge_state[i] = builder.add(self.sponge_state[i], input);
+            }
+
+            // Apply the permutation.
+            self.sponge_state = builder.rescue_permutation(&self.sponge_state);
+        }
+
+        self.input_buffer.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CircuitBuilder, Curve, Field, PartialWitness, Target, Tweedledum};
+    use crate::plonk_challenger::{Challenger, RecursiveChallenger};
+
+    /// Tests for consistency between `Challenger` and `RecursiveChallenger`.
+    #[test]
+    fn test_consistency() {
+        type C = Tweedledum;
+        type SF = <C as Curve>::ScalarField;
+
+        // These are mostly arbitrary, but we want to test some rounds with enough inputs/outputs to
+        // trigger multiple absorptions/squeezes.
+        let num_inputs_per_round = vec![2, 5, 3];
+        let num_outputs_per_round = vec![1, 2, 4];
+
+        // Generate random input messages.
+        let inputs_per_round: Vec<Vec<SF>> = num_inputs_per_round.iter()
+            .map(|&n| (0..n).map(|_| SF::rand()).collect::<Vec<_>>())
+            .collect();
+
+        let mut challenger = Challenger::new(128);
+        let mut outputs_per_round: Vec<Vec<SF>> = Vec::new();
+        for (r, inputs) in inputs_per_round.iter().enumerate() {
+            challenger.observe_elements(inputs);
+            outputs_per_round.push(challenger.get_n_challenges(num_outputs_per_round[r]));
+        }
+
+        let mut builder = CircuitBuilder::<C>::new(128);
+        let mut recursive_challenger = RecursiveChallenger::new(&mut builder);
+        let mut recursive_outputs_per_round: Vec<Vec<Target>> = Vec::new();
+        for (r, inputs) in inputs_per_round.iter().enumerate() {
+            recursive_challenger.observe_elements(&builder.constant_wires(inputs));
+            recursive_outputs_per_round.push(
+                recursive_challenger.get_n_challenges(
+                    &mut builder, num_outputs_per_round[r]));
+        }
+        let circuit = builder.build();
+        let witness = circuit.generate_partial_witness(PartialWitness::new());
+        let recursive_output_values_per_round: Vec<Vec<SF>> = recursive_outputs_per_round.iter()
+            .map(|outputs| witness.get_targets(outputs))
+            .collect();
+
+        assert_eq!(outputs_per_round, recursive_output_values_per_round);
     }
 }

--- a/src/plonk_challenger.rs
+++ b/src/plonk_challenger.rs
@@ -117,6 +117,8 @@ impl<F: Field> Challenger<F> {
             self.sponge_state = rescue_permutation(&self.sponge_state, self.security_bits);
         }
 
+        self.output_buffer = self.sponge_state[0..RESCUE_SPONGE_RATE].to_vec();
+
         self.input_buffer.clear();
     }
 }
@@ -206,6 +208,8 @@ impl<C: HaloCurve> RecursiveChallenger<C> {
             // Apply the permutation.
             self.sponge_state = builder.rescue_permutation(&self.sponge_state);
         }
+
+        self.output_buffer = self.sponge_state[0..RESCUE_SPONGE_RATE].to_vec();
 
         self.input_buffer.clear();
     }

--- a/src/plonk_recursion.rs
+++ b/src/plonk_recursion.rs
@@ -100,7 +100,7 @@ pub fn recursive_verification_circuit<
     // Can call curve_assert_valid.
 
     // Compute random challenges.
-    let mut challenger = RecursiveChallenger::<C>::new();
+    let mut challenger = RecursiveChallenger::<C>::new(&mut builder);
     challenger.observe_affine_points(&proof.c_wires);
     let (beta, gamma) = challenger.get_2_challenges(&mut builder);
     challenger.observe_affine_point(proof.c_plonk_z);

--- a/src/rescue.rs
+++ b/src/rescue.rs
@@ -51,7 +51,7 @@ pub fn rescue_sponge<F: Field>(inputs: Vec<F>, num_outputs: usize, security_bits
         for i in 0..input_chunk.len() {
             state[i] = state[i] + input_chunk[i];
         }
-        state = rescue_permutation(state, security_bits);
+        state = rescue_permutation(&state, security_bits);
     }
 
     // Squeeze until we have the desired number of outputs.
@@ -63,11 +63,12 @@ pub fn rescue_sponge<F: Field>(inputs: Vec<F>, num_outputs: usize, security_bits
                 return outputs;
             }
         }
-        state = rescue_permutation(state, security_bits);
+        state = rescue_permutation(&state, security_bits);
     }
 }
 
-pub fn rescue_permutation<F: Field>(mut state: Vec<F>, security_bits: usize) -> Vec<F> {
+pub fn rescue_permutation<F: Field>(state: &[F], security_bits: usize) -> Vec<F> {
+    let mut state = state.to_vec();
     let width = state.len();
     let constants = generate_rescue_constants(width, security_bits);
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -37,6 +37,10 @@ impl<F: Field> PartialWitness<F> {
         self.wire_values[&target]
     }
 
+    pub fn get_targets(&self, targets: &[Target]) -> Vec<F> {
+        targets.iter().map(|&t| self.get_target(t)).collect()
+    }
+
     pub fn get_point_target<InnerC: Curve<BaseField = F>>(
         &self,
         target: AffinePointTarget,


### PR DESCRIPTION
This may save us some evaluations of the permutation, since we no longer have to save one of the outputs and pass it in as an input to the next hash. The sponge already has "memory" of previous messages via its capacity element.

Inspired by @daira's talk: https://www.youtube.com/watch?v=IQVGIqcdxL4&t=50m05s