### PR TITLE
Avoid copying in IFFT code, and add benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0.31"
 once_cell = "1.4.0"
 
 [dev-dependencies]
-criterion = "0.3.2"
+criterion = "0.3.3"
 
 [[bench]]
 name = "bigint_arithmetic"
@@ -51,6 +51,10 @@ harness = false
 
 [[bench]]
 name = "hash_to_curve"
+harness = false
+
+[[bench]]
+name = "fft"
 harness = false
 
 [profile.release]

--- a/benches/fft.rs
+++ b/benches/fft.rs
@@ -1,0 +1,64 @@
+use criterion::{black_box, Criterion};
+use criterion::criterion_group;
+use criterion::{BenchmarkId, criterion_main, SamplingMode};
+
+use plonky::{Field, TweedledeeBase, fft_precompute, ifft_with_precomputation_power_of_2, fft_with_precomputation_power_of_2};
+use std::time::Duration;
+
+type F = TweedledeeBase;
+
+const DEGREE_LOG_MIN: usize = 1;
+const DEGREE_LOG_MAX: usize = 18;
+
+fn degree_logs() -> Vec<usize> {
+    (DEGREE_LOG_MIN..=DEGREE_LOG_MAX).collect()
+}
+
+fn fft(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fft");
+
+    for degree_log in degree_logs() {
+        let degree = 1 << degree_log;
+        let precomputation = fft_precompute(degree);
+        let coeffs: Vec<F> = (0..degree).map(|_| F::rand()).collect();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("2_exp_{}", degree_log)),
+            &degree_log, 
+            |b, &_degree_log| {
+                b.iter(|| {
+                    fft_with_precomputation_power_of_2(black_box(&coeffs), &precomputation);
+                });
+            }
+        );
+    }
+}
+
+fn ifft(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ifft");
+
+    for degree_log in degree_logs() {
+        let degree = 1 << degree_log;
+        let precomputation = fft_precompute(degree);
+        let points: Vec<F> = (0..degree).map(|_| F::rand()).collect();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("2_exp_{}", degree_log)),
+            &degree_log, 
+            |b, &_degree_log| {
+                b.iter(|| {
+                    ifft_with_precomputation_power_of_2(black_box(&points), &precomputation);
+                });
+            }
+        );
+    }
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1));
+    targets = fft, ifft
+);
+
+criterion_main!(benches);

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -24,6 +24,7 @@ fn reverse_bits(n: usize, num_bits: usize) -> usize {
     result
 }
 
+#[derive(Clone)]
 pub struct FftPrecomputation<F: Field> {
     /// For each layer index i, stores the cyclic subgroup corresponding to the evaluation domain of
     /// layer i. The indices within these subgroup vectors are bit-reversed.
@@ -76,14 +77,19 @@ pub fn ifft_with_precomputation_power_of_2<F: Field>(
 ) -> Vec<F> {
     let n = points.len();
     let n_inv = F::from_canonical_usize(n).multiplicative_inverse().unwrap();
-    let result = fft_with_precomputation_power_of_2(points, precomputation);
-    // TODO: Could do this in-place with swaps.
-    let mut coefficients = Vec::with_capacity(n);
-    coefficients.push(result[0] * n_inv);
-    for x in result.into_iter().skip(1).rev() {
-        coefficients.push(x * n_inv);
+    let mut result = fft_with_precomputation_power_of_2(points, precomputation);
+
+    // We reverse all values except the first, and divide each by n.
+    result[0] = result[0] * n_inv;
+    result[n / 2] = result[n / 2] * n_inv;
+    for i in 1..(n / 2) {
+        let j = n - i;
+        let result_i = result[j] * n_inv;
+        let result_j = result[i] * n_inv;
+        result[i] = result_i;
+        result[j] = result_j;
     }
-    coefficients
+    result
 }
 
 pub fn fft_with_precomputation_power_of_2<F: Field>(


### PR DESCRIPTION
Tested with `cargo bench ifft/2_exp_18`. There seems to be a bit of speedup, although timing is pretty noisy on my machine, so it's hard to measure accurately.