### PR TITLE
Added plookup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["cryptography"]
 edition = "2018"
 default-run = "recursion"
 
+[workspace]
+members = ["plookup"]
+
 [dependencies]
 getrandom = "0.1.14"
 num = "0.2.1"

--- a/plookup/.gitignore
+++ b/plookup/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/plookup/Cargo.toml
+++ b/plookup/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "plookup"
+version = "0.1.0"
+authors = ["wborgeaud <williamborgeaud@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+plonky = {path="../../plonky"}
+anyhow = "1.0.31"
+rand = "0.7.3"
+itertools = "0.9.0"
+num = "0.2.1"

--- a/plookup/README.md
+++ b/plookup/README.md
@@ -1,0 +1,4 @@
+# Plookup on Plonky
+
+### Notes
+Uses const generics and thus requires Rust nightly.

--- a/plookup/src/lib.rs
+++ b/plookup/src/lib.rs
@@ -1,0 +1,7 @@
+#![feature(const_generics)]
+
+mod openings;
+pub mod plookup;
+mod proof;
+pub mod table;
+pub mod verifier;

--- a/plookup/src/openings.rs
+++ b/plookup/src/openings.rs
@@ -1,0 +1,99 @@
+use plonky::plonk_util::eval_poly;
+use plonky::Field;
+
+pub struct Opening<F: Field> {
+    pub local: F,
+    pub right: F,
+}
+
+impl<F: Field> Opening<F> {
+    fn to_vec(&self) -> Vec<F> {
+        vec![self.local, self.right]
+    }
+}
+
+impl<F: Field> From<(F, F)> for Opening<F> {
+    fn from(t: (F, F)) -> Self {
+        Self {
+            local: t.0,
+            right: t.1,
+        }
+    }
+}
+
+/// Struct containing all polynomial openings used in the Plookup protocol.
+pub struct PlookupOpenings<F: Field> {
+    pub f: Opening<F>,
+    pub t: Opening<F>,
+    pub h1: Opening<F>,
+    pub h2: Opening<F>,
+    pub z: Opening<F>,
+    pub quotient: Opening<F>,
+}
+
+impl<F: Field> PlookupOpenings<F> {
+    pub fn to_vec(&self) -> Vec<F> {
+        [
+            self.f.to_vec(),
+            self.t.to_vec(),
+            self.h1.to_vec(),
+            self.h2.to_vec(),
+            self.z.to_vec(),
+            self.quotient.to_vec(),
+        ]
+        .concat()
+    }
+
+    pub fn local(&self) -> Vec<F> {
+        vec![
+            self.f.local,
+            self.t.local,
+            self.h1.local,
+            self.h2.local,
+            self.z.local,
+            self.quotient.local,
+        ]
+    }
+
+    pub fn right(&self) -> Vec<F> {
+        vec![
+            self.f.right,
+            self.t.right,
+            self.h1.right,
+            self.h2.right,
+            self.z.right,
+            self.quotient.right,
+        ]
+    }
+}
+
+pub fn open_all_polynomials<F: Field>(
+    f_coeffs: &[F],
+    t_coeffs: &[F],
+    h1_coeffs: &[F],
+    h2_coeffs: &[F],
+    z_coeffs: &[F],
+    quotient_coeffs: &[F],
+    zeta: F,
+    generator: F,
+) -> PlookupOpenings<F> {
+    let right = zeta * generator;
+    let f = (eval_poly(f_coeffs, zeta), eval_poly(f_coeffs, right)).into();
+    let t = (eval_poly(t_coeffs, zeta), eval_poly(t_coeffs, right)).into();
+    let h1 = (eval_poly(h1_coeffs, zeta), eval_poly(h1_coeffs, right)).into();
+    let h2 = (eval_poly(h2_coeffs, zeta), eval_poly(h2_coeffs, right)).into();
+    let z = (eval_poly(z_coeffs, zeta), eval_poly(z_coeffs, right)).into();
+    let quotient = (
+        eval_poly(quotient_coeffs, zeta),
+        eval_poly(quotient_coeffs, right),
+    )
+        .into();
+    PlookupOpenings {
+        f,
+        t,
+        h1,
+        h2,
+        z,
+        quotient,
+    }
+}

--- a/plookup/src/plookup.rs
+++ b/plookup/src/plookup.rs
@@ -1,0 +1,312 @@
+use crate::openings::open_all_polynomials;
+use crate::proof::PlookupProof;
+use anyhow::Result;
+use plonky;
+use plonky::halo::batch_opening_proof;
+use plonky::plonk_challenger::Challenger;
+use plonky::plonk_util::reduce_with_powers;
+use plonky::util::log2_strict;
+use plonky::{
+    blake_hash_usize_to_curve, divide_by_z_h, fft_precompute, fft_with_precomputation,
+    ifft_with_precomputation_power_of_2, msm_precompute, AffinePoint, Field, HaloCurve,
+    PolynomialCommitment,
+};
+
+pub const SECURITY_BITS: usize = 128;
+
+/// Computes a proof that `t` is a sub(multi)set of `f`, following the Plookup protocol (https://ia.cr/2020/315).
+pub fn prove<C: HaloCurve>(f: &[C::ScalarField], t: &[C::ScalarField]) -> Result<PlookupProof<C>> {
+    let (n, f, t) = pad_inputs(f, t);
+
+    // Compute the `s` multiset of the Plookup protocol.
+    let mut s = f.clone();
+    s.extend_from_slice(&t);
+    sort_by(&mut s, &t);
+
+    // Initiate the Fiat-Shamir challenger.
+    let mut challenger = Challenger::new(SECURITY_BITS);
+
+    // FFT precomputation on the cyclic subgroup of order `n+1`.
+    let fft_precomputation = fft_precompute(n + 1);
+
+    // Compute the coefficients of the polynomials corresponding to `f`, `t`, `h1` and `h2`.
+    let f_padded = padded(&f, n + 1);
+    let f_coeffs = ifft_with_precomputation_power_of_2(&f_padded, &fft_precomputation);
+    let t_coeffs = ifft_with_precomputation_power_of_2(&t, &fft_precomputation);
+    let h1_coeffs = ifft_with_precomputation_power_of_2(&s[..n + 1], &fft_precomputation);
+    let h2_coeffs = ifft_with_precomputation_power_of_2(&s[n..], &fft_precomputation);
+
+    // Curve points used in the IPA.
+    let gs = (0..2 * n + 2)
+        .map(|i| blake_hash_usize_to_curve::<C>(i))
+        .collect::<Vec<_>>();
+    let h = blake_hash_usize_to_curve(2 * n + 2);
+    let u_curve = blake_hash_usize_to_curve(2 * n + 3);
+    let msm_precomputation = msm_precompute(&AffinePoint::batch_to_projective(&gs[..n + 1]), 8);
+    let msm_precomputation_2n2 = msm_precompute(&AffinePoint::batch_to_projective(&gs), 8);
+
+    // Commit to all polynomials.
+    let c_f = PolynomialCommitment::coeffs_to_commitment(&f_coeffs, &msm_precomputation, h, true);
+    let c_t = PolynomialCommitment::coeffs_to_commitment(&t_coeffs, &msm_precomputation, h, false);
+    let c_h1 =
+        PolynomialCommitment::coeffs_to_commitment(&h1_coeffs, &msm_precomputation, h, false);
+    let c_h2 =
+        PolynomialCommitment::coeffs_to_commitment(&h2_coeffs, &msm_precomputation, h, false);
+
+    // Observe the commitments to get verifier challenges.
+    // `beta` and `gamma` are used to construct the Plookup grand product.
+    challenger.observe_affine_points(&[
+        c_f.to_affine(),
+        c_t.to_affine(),
+        c_h1.to_affine(),
+        c_h2.to_affine(),
+    ]);
+    let (beta_bf, gamma_bf) = challenger.get_2_challenges();
+    let beta = C::BaseField::try_convert(&beta_bf).unwrap();
+    let gamma = C::BaseField::try_convert(&gamma_bf).unwrap();
+
+    // Compute and commit to the `z` grand product polynomial of Plookup.
+    // `f` is a subset of `t` iff this polynomial is well-formed and its last value is 1.
+    let z_values = grand_polynomial(&f, &t, &s, beta, gamma);
+    let z_coeffs = ifft_with_precomputation_power_of_2(&z_values, &fft_precomputation);
+    let c_z = PolynomialCommitment::coeffs_to_commitment(&z_coeffs, &msm_precomputation, h, true);
+
+    // Observe the commitment to get a verifier challenge.
+    // `alpha` is used to batch all vanishing polynomials.
+    challenger.observe_affine_point(c_z.to_affine());
+    let alpha_bf = challenger.get_challenge();
+    let alpha = C::BaseField::try_convert(&alpha_bf).unwrap();
+
+    // Compute the coefficients of the "vanishing polynomial".
+    // `f` is a subset of `t` iff this polynomial vanishes on subgroup `H`.
+    let vanishing_coeffs = vanishing_polynomial_coeffs(
+        &f_coeffs, &t_coeffs, &h1_coeffs, &h2_coeffs, &z_coeffs, beta, gamma, alpha, n,
+    );
+
+    // Commit to the quotient of the vanishing polynomial by `x^(n+1) - 1`. The quotient exists
+    // because the vanishing polynomial vanishes on `H`.
+    let mut quotient_coeffs = divide_by_z_h(&vanishing_coeffs, n + 1);
+    plonky::trim(&mut quotient_coeffs);
+    assert!(quotient_coeffs.len() <= 2 * n + 1);
+    let c_quotient = PolynomialCommitment::coeffs_to_commitment(
+        &padded(&quotient_coeffs, 2 * n + 2),
+        &msm_precomputation_2n2,
+        h,
+        true,
+    );
+
+    // Observe the commitment to get a verifier challenge.
+    // `zeta` is the point at which we'll open all polynomials.
+    challenger.observe_affine_point(c_quotient.to_affine());
+    let zeta_bf = challenger.get_challenge();
+    let zeta: C::ScalarField = C::BaseField::try_convert(&zeta_bf).unwrap();
+
+    // Open all polynomials.
+    let generator = C::ScalarField::primitive_root_of_unity(log2_strict(n + 1));
+    let openings = open_all_polynomials(
+        &f_coeffs,
+        &t_coeffs,
+        &h1_coeffs,
+        &h2_coeffs,
+        &z_coeffs,
+        &quotient_coeffs,
+        zeta,
+        generator,
+    );
+
+    // Observe the openings to get verifier challenges.
+    // `v`, `u` and `u_scaling` are used in the IPA proof.
+    let openings_bf: Vec<_> = openings
+        .to_vec()
+        .into_iter()
+        .map(|f| {
+            C::try_convert_s2b(f)
+                .expect("For now, we assume that all opened values fit in both fields")
+        })
+        .collect();
+    challenger.observe_elements(&openings_bf);
+    let (v_bf, u_bf, u_scaling_bf) = challenger.get_3_challenges();
+    let v = v_bf.try_convert::<C::ScalarField>()?;
+    let u = u_bf.try_convert::<C::ScalarField>()?;
+    let u_scaling = u_scaling_bf.try_convert::<C::ScalarField>()?;
+
+    let commitments = vec![c_f, c_t, c_h1, c_h2, c_z, c_quotient];
+
+    let coeffs = vec![
+        padded(&f_coeffs, 2 * n + 2),
+        padded(&t_coeffs, 2 * n + 2),
+        padded(&h1_coeffs, 2 * n + 2),
+        padded(&h2_coeffs, 2 * n + 2),
+        padded(&z_coeffs, 2 * n + 2),
+        padded(&quotient_coeffs, 2 * n + 2),
+    ];
+
+    // Compute the Halo opening proof.
+    let halo_proof = batch_opening_proof(
+        &coeffs.iter().map(|c| c.as_slice()).collect::<Vec<_>>(),
+        &commitments,
+        &[zeta, zeta * generator],
+        &gs,
+        h.to_projective(),
+        u_curve,
+        u,
+        v,
+        u_scaling,
+        2 * n + 2,
+        SECURITY_BITS,
+        &mut challenger,
+    )?;
+
+    Ok(PlookupProof::from((commitments, openings, halo_proof, n)))
+}
+
+fn pad_inputs<F: Field>(f: &[F], t: &[F]) -> (usize, Vec<F>, Vec<F>) {
+    let d = t.len();
+    let f = if f.len() + 1 < d {
+        padded(f, d - 1)
+    } else {
+        f.to_vec()
+    };
+    let n = f.len().next_power_of_two() - 1;
+
+    let f = padded(&f, n);
+    let t = padded(t, n + 1);
+    (n, f, t)
+}
+
+/// Sorts a vector `f` by another `t` in-place. `f` is sorted by `t` if `f` is a subset of `t`,
+/// and elements of `f` appear in the same order as elements of `t`.
+fn sort_by<F: Field>(f: &mut [F], t: &[F]) {
+    f.sort_by(|a, b| {
+        let i = t.iter().position(|x| x == a).unwrap();
+        let j = t.iter().position(|x| x == b).unwrap();
+        i.cmp(&j)
+    });
+}
+
+/// Computes the Plookup grand product polynomial.
+fn grand_polynomial<F: Field>(f: &[F], t: &[F], s: &[F], beta: F, gamma: F) -> Vec<F> {
+    let n = f.len();
+    let mut values = vec![F::ONE];
+
+    let beta1 = beta + F::ONE;
+    let gamma_beta1 = gamma * beta1;
+    let mut beta1_pow = beta1;
+    let mut prod_a = gamma + f[0];
+    let mut prod_b = gamma_beta1 + t[0] + beta * t[1];
+    let mut prod_c = (gamma_beta1 + s[0] + beta * s[1]) * (gamma_beta1 + s[n] + beta * s[n + 1]);
+    for i in 1..n {
+        values.push((beta1_pow * prod_a * prod_b) / prod_c);
+
+        beta1_pow = beta1_pow * beta1;
+        prod_a = prod_a * (gamma + f[i]);
+        prod_b = prod_b * (gamma_beta1 + t[i] + beta * t[i + 1]);
+        prod_c = prod_c
+            * (gamma_beta1 + s[i] + beta * s[i + 1])
+            * (gamma_beta1 + s[n + i] + beta * s[n + i + 1]);
+    }
+    values.push(F::ONE);
+    values
+}
+
+/// Computes the Plookup vanishing polynomial.
+fn vanishing_polynomial_coeffs<F: Field>(
+    f_coeffs: &[F],
+    t_coeffs: &[F],
+    h1_coeffs: &[F],
+    h2_coeffs: &[F],
+    z_coeffs: &[F],
+    beta: F,
+    gamma: F,
+    alpha: F,
+    n: usize,
+) -> Vec<F> {
+    let order = 4 * (n + 1);
+    let generator_4 = F::primitive_root_of_unity(log2_strict(order));
+    let fft_precomp4 = fft_precompute(order);
+    let z_4_values = fft_with_precomputation(&padded(z_coeffs, order), &fft_precomp4);
+    let f_4_values = fft_with_precomputation(&padded(f_coeffs, order), &fft_precomp4);
+    let t_4_values = fft_with_precomputation(&padded(t_coeffs, order), &fft_precomp4);
+    let h1_4_values = fft_with_precomputation(&padded(h1_coeffs, order), &fft_precomp4);
+    let h2_4_values = fft_with_precomputation(&padded(h2_coeffs, order), &fft_precomp4);
+
+    let beta1 = beta + F::ONE;
+    let gamma_beta1 = gamma * beta1;
+
+    let values = F::cyclic_subgroup_known_order(generator_4, order)
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| {
+            let vanishing_z1_term =
+                eval_l_i(n + 1, 0, generator_4.exp_usize(4), x) * (z_4_values[i] - F::ONE);
+            let next = (i + 4) % order;
+            let vanishing_shift_term = (x - generator_4.exp_usize(4 * n))
+                * z_4_values[i]
+                * beta1
+                * (gamma + f_4_values[i])
+                * (gamma_beta1 + t_4_values[i] + beta * t_4_values[next])
+                - (x - generator_4.exp_usize(4 * n))
+                    * z_4_values[next]
+                    * (gamma_beta1 + h1_4_values[i] + beta * h1_4_values[next])
+                    * (gamma_beta1 + h2_4_values[i] + beta * h2_4_values[next]);
+            let eval_last = eval_l_i(n + 1, n, generator_4.exp_usize(4), x);
+            let vanishing_hs_term = eval_last * (h1_4_values[i] - h2_4_values[next]);
+            let vanishing_last_term = eval_last * (z_4_values[i] - F::ONE);
+
+            if cfg!(debug_assertions) && i % 4 == 0 {
+                for &x in &[
+                    vanishing_z1_term,
+                    vanishing_shift_term,
+                    vanishing_hs_term,
+                    vanishing_last_term,
+                ] {
+                    assert_eq!(x, F::ZERO);
+                }
+            }
+
+            reduce_with_powers(
+                &[
+                    vanishing_z1_term,
+                    vanishing_shift_term,
+                    vanishing_hs_term,
+                    vanishing_last_term,
+                ],
+                alpha,
+            )
+        })
+        .collect::<Vec<_>>();
+    ifft_with_precomputation_power_of_2(&values, &fft_precomp4)
+}
+
+/// Computes the evaluation of the `i`-th Lagrange basis polynomial of order `n` on a point `x`.
+/// Uses the formula `L_i(x) = w^i(x^n - 1) / n(x-w^i)`.
+pub fn eval_l_i<F: Field>(n: usize, i: usize, generator: F, x: F) -> F {
+    let g = generator.exp_usize(i);
+    if x == g {
+        F::ZERO
+    } else {
+        g * (x.exp_usize(n) - F::ONE) / (F::from_canonical_usize(n) * (x - g))
+    }
+}
+
+/// Zero-pad a slice to have length `n`.
+pub fn padded<F: Field>(s: &[F], n: usize) -> Vec<F> {
+    let mut pad = s.to_vec();
+    pad.extend((s.len()..n).map(|_| F::ZERO));
+    pad
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::plookup::sort_by;
+    use plonky::{Field, TweedledeeBase};
+
+    #[test]
+    fn test_sort_by() {
+        type F = TweedledeeBase;
+        let mut f = vec![F::FIVE, F::TWO, F::ONE];
+        let t = vec![F::ONE, F::TWO, F::THREE, F::FOUR, F::FIVE];
+        sort_by(&mut f, &t);
+        assert_eq!(f, vec![F::ONE, F::TWO, F::FIVE]);
+    }
+}

--- a/plookup/src/proof.rs
+++ b/plookup/src/proof.rs
@@ -1,0 +1,127 @@
+use crate::openings::PlookupOpenings;
+use crate::plookup::SECURITY_BITS;
+use anyhow::{anyhow, Result};
+use plonky::halo::OpeningProof;
+use plonky::plonk_challenger::Challenger;
+use plonky::plonk_util::halo_n;
+use plonky::{AffinePoint, Curve, Field, HaloCurve, PolynomialCommitment};
+
+// TODO: The verifier should somehow have access to `c_f`, so we can probably remove it from the proof or make it optional.
+pub struct PlookupProof<C: HaloCurve> {
+    pub c_f: AffinePoint<C>,
+    pub c_t: AffinePoint<C>,
+    pub c_h1: AffinePoint<C>,
+    pub c_h2: AffinePoint<C>,
+    pub c_z: AffinePoint<C>,
+    pub c_quotient: AffinePoint<C>,
+    pub openings: PlookupOpenings<C::ScalarField>,
+    pub halo_proof: OpeningProof<C>,
+    pub n: usize,
+}
+
+impl<C: HaloCurve>
+    From<(
+        Vec<PolynomialCommitment<C>>,
+        PlookupOpenings<C::ScalarField>,
+        OpeningProof<C>,
+        usize,
+    )> for PlookupProof<C>
+{
+    fn from(
+        mut t: (
+            Vec<PolynomialCommitment<C>>,
+            PlookupOpenings<C::ScalarField>,
+            OpeningProof<C>,
+            usize,
+        ),
+    ) -> Self {
+        PolynomialCommitment::batch_to_affine(&mut t.0);
+        Self {
+            c_f: t.0[0].to_affine(),
+            c_t: t.0[1].to_affine(),
+            c_h1: t.0[2].to_affine(),
+            c_h2: t.0[3].to_affine(),
+            c_z: t.0[4].to_affine(),
+            c_quotient: t.0[5].to_affine(),
+            openings: t.1,
+            halo_proof: t.2,
+            n: t.3,
+        }
+    }
+}
+
+pub struct PlookupProofChallenge<C: Curve> {
+    pub beta: C::ScalarField,
+    pub gamma: C::ScalarField,
+    pub alpha: C::ScalarField,
+    pub zeta: C::ScalarField,
+    pub v: C::ScalarField,
+    pub u: C::ScalarField,
+    pub u_scaling: C::ScalarField,
+    pub halo_us: Vec<C::ScalarField>,
+    pub schnorr_challenge: C::ScalarField,
+}
+
+impl<C: HaloCurve> PlookupProof<C> {
+    pub fn get_challenges(&self) -> Result<PlookupProofChallenge<C>> {
+        let mut challenger = Challenger::new(SECURITY_BITS);
+        let error_msg = "Conversion from base to scalar field failed.";
+        challenger.observe_affine_points(&[self.c_f, self.c_t, self.c_h1, self.c_h2]);
+        let (beta_bf, gamma_bf) = challenger.get_2_challenges();
+        let beta = C::try_convert_b2s(beta_bf).map_err(|_| anyhow!(error_msg))?;
+        let gamma = C::try_convert_b2s(gamma_bf).map_err(|_| anyhow!(error_msg))?;
+        challenger.observe_affine_point(self.c_z);
+        let alpha_bf = challenger.get_challenge();
+        let alpha = C::try_convert_b2s(alpha_bf).map_err(|_| anyhow!(error_msg))?;
+        challenger.observe_affine_point(self.c_quotient);
+        let zeta_bf = challenger.get_challenge();
+        let zeta = C::try_convert_b2s(zeta_bf).map_err(|_| anyhow!(error_msg))?;
+        let openings_bf: Vec<_> = self
+            .openings
+            .to_vec()
+            .into_iter()
+            .map(|f| {
+                C::try_convert_s2b(f)
+                    .expect("For now, we assume that all opened values fit in both fields")
+            })
+            .collect();
+        challenger.observe_elements(&openings_bf);
+        let (v_bf, u_bf, u_scaling_bf) = challenger.get_3_challenges();
+        let v = C::try_convert_b2s(v_bf).map_err(|_| anyhow!(error_msg))?;
+        let u = C::try_convert_b2s(u_bf).map_err(|_| anyhow!(error_msg))?;
+        let u_scaling = C::try_convert_b2s(u_scaling_bf).map_err(|_| anyhow!(error_msg))?;
+
+        // Compute IPA challenges.
+        let mut halo_us = Vec::new();
+        for i in 0..self.halo_proof.halo_l.len() {
+            challenger
+                .observe_affine_points(&[self.halo_proof.halo_l[i], self.halo_proof.halo_r[i]]);
+            let r_bf = challenger.get_challenge();
+            let r_sf = r_bf.try_convert::<C::ScalarField>()?;
+            let r_bits = &r_sf.to_canonical_bool_vec()[..SECURITY_BITS];
+            let u_j_squared = halo_n::<C>(r_bits);
+            let u_j = u_j_squared
+                .square_root()
+                .expect("Prover should have ensured that n(r) is square");
+            halo_us.push(u_j);
+        }
+
+        // Compute challenge for Schnorr protocol.
+        challenger.observe_affine_point(self.halo_proof.schnorr_proof.r);
+        let schnorr_challenge_bf = challenger.get_challenge();
+        let schnorr_challenge =
+            C::try_convert_b2s(schnorr_challenge_bf).map_err(|_| anyhow!(error_msg))?;
+
+        Ok(PlookupProofChallenge {
+            beta,
+            gamma,
+            alpha,
+            zeta,
+            v,
+            u,
+            u_scaling,
+            halo_us,
+            schnorr_challenge,
+        })
+    }
+}

--- a/plookup/src/table.rs
+++ b/plookup/src/table.rs
@@ -1,0 +1,123 @@
+use crate::plookup::{prove, SECURITY_BITS};
+use crate::proof::PlookupProof;
+use crate::verifier::verify;
+use anyhow::Result;
+use itertools::Itertools;
+use plonky::plonk_challenger::Challenger;
+use plonky::{Field, HaloCurve};
+
+/// A `Table` is a list of rows of field elements, all with size `N`.
+pub struct Table<F: Field, const N: usize>(pub Vec<[F; N]>);
+
+impl<F: Field, const N: usize> Table<F, N> {
+    /// Constructs a `Table` with width `N` from a function `F^(N-1) -> F` and an evaluation domain
+    /// `domain \subseteq F^(N-1)`.
+    pub fn from_function<const M: usize>(f: &dyn Fn([F; M]) -> F, domain: &[[F; M]]) -> Self {
+        assert_eq!(M, N - 1);
+        Self(
+            domain
+                .iter()
+                .map(|&a| {
+                    let mut arr = [F::ZERO; N];
+                    for (x, &y) in arr.iter_mut().zip(a.iter()) {
+                        *x = y;
+                    }
+                    arr[N - 1] = f(a);
+                    arr
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Constructs a `Table` with width `N` from a function `F^(N-1) -> F` and an evaluation domain
+    /// `domain^(N-1) \subseteq F^(N-1)`.
+    pub fn from_function_cartesian<const M: usize>(f: &dyn Fn([F; M]) -> F, domain: &[F]) -> Self {
+        assert_eq!(M, N - 1);
+        let cartesian_domain = (0..M).map(|_| domain.iter()).multi_cartesian_product();
+        Self(
+            cartesian_domain
+                .map(|a| {
+                    let mut arr = [F::ZERO; N];
+                    for (x, &&y) in arr.iter_mut().zip(a.iter()) {
+                        *x = y;
+                    }
+                    let mut src = [F::ZERO; M];
+                    src.copy_from_slice(&a.iter().map(|x| **x).collect::<Vec<_>>());
+                    arr[N - 1] = f(src);
+                    arr
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Get a verifier challenge from a `Table`. Used to reduce a `Table` to a vector.
+    fn get_challenge(&self) -> F {
+        let mut challenger = Challenger::new(SECURITY_BITS);
+        for a in &self.0 {
+            challenger.observe_elements(a);
+        }
+        challenger.get_challenge()
+    }
+
+    /// Reduces a `Table` to a vector using a random challenge.
+    pub fn to_vec(&self) -> Vec<F> {
+        let alpha = self.get_challenge();
+        self.0
+            .iter()
+            .map(|a| a.iter().fold(F::ZERO, |acc, &x| alpha * acc + x))
+            .collect()
+    }
+
+    /// Reduces a `Table` and a subset thereof to two vectors using a random challenge.
+    fn to_vecs_with_row_witnesses(&self, ws: &Self) -> (Vec<F>, Vec<F>) {
+        let alpha = self.get_challenge();
+        (
+            self.0
+                .iter()
+                .map(|a| a.iter().fold(F::ZERO, |acc, &x| alpha * acc + x))
+                .collect(),
+            ws.0.iter()
+                .map(|a| a.iter().fold(F::ZERO, |acc, &x| alpha * acc + x))
+                .collect(),
+        )
+    }
+
+    /// Reduces a `Table` and vector of columns to two vectors using a random challenge.
+    fn to_vecs_with_column_witnesses(&self, ws: &[Vec<F>; N]) -> (Vec<F>, Vec<F>) {
+        let alpha = self.get_challenge();
+        let h = ws[0].len();
+        (
+            self.0
+                .iter()
+                .map(|a| a.iter().fold(F::ZERO, |acc, &x| alpha * acc + x))
+                .collect(),
+            (0..h)
+                .map(|i| {
+                    (0..N)
+                        .map(|j| ws[j][i])
+                        .fold(F::ZERO, |acc, x| alpha * acc + x)
+                })
+                .collect(),
+        )
+    }
+
+    /// Proves that `ws` is a subtable of `self` using the Plookup protocol.
+    pub fn prove_row<C: HaloCurve<ScalarField = F>>(&self, ws: &Self) -> Result<PlookupProof<C>> {
+        let (t, f) = self.to_vecs_with_row_witnesses(ws);
+        prove(&f, &t)
+    }
+
+    /// Proves that the columns `ws` form a subtable of `self` using the Plookup protocol.
+    pub fn prove_column<C: HaloCurve<ScalarField = F>>(
+        &self,
+        ws: &[Vec<F>; N],
+    ) -> Result<PlookupProof<C>> {
+        let (t, f) = self.to_vecs_with_column_witnesses(ws);
+        prove(&f, &t)
+    }
+
+    /// Verifies that a proof is valid for a table `t`.
+    pub fn verify<C: HaloCurve<ScalarField = F>>(&self, proof: &PlookupProof<C>) -> Result<()> {
+        verify(&self.to_vec(), proof)
+    }
+}

--- a/plookup/src/verifier.rs
+++ b/plookup/src/verifier.rs
@@ -1,0 +1,159 @@
+use crate::plookup::{eval_l_i, padded, SECURITY_BITS};
+use crate::proof::{PlookupProof, PlookupProofChallenge};
+use anyhow::{ensure, Result};
+use plonky::halo::verify_ipa;
+use plonky::plonk_util::{halo_g, halo_n, halo_n_mul, powers, reduce_with_powers};
+use plonky::util::log2_strict;
+use plonky::{
+    blake_hash_usize_to_curve, fft_precompute, ifft_with_precomputation_power_of_2,
+    msm_execute_parallel, msm_precompute, AffinePoint, Field, HaloCurve, PolynomialCommitment,
+};
+
+/// Verifies that a proof is valid for a set `t`.
+/// TODO: The verifier should have some auxiliary knowledge of `c_t`. For now, it is stored in the `proof`.
+pub fn verify<C: HaloCurve>(t: &[C::ScalarField], proof: &PlookupProof<C>) -> Result<()> {
+    let n = proof.n;
+    let t = padded(t, n + 1);
+    let fft_precomputation = fft_precompute(n + 1);
+    let gs = (0..2 * n + 2)
+        .map(|i| blake_hash_usize_to_curve::<C>(i))
+        .collect::<Vec<_>>();
+    let h = blake_hash_usize_to_curve(2 * n + 2);
+    let u_curve = blake_hash_usize_to_curve(2 * n + 3);
+    let t_coeffs = ifft_with_precomputation_power_of_2(&t, &fft_precomputation);
+    let msm_precomputation = msm_precompute(&AffinePoint::batch_to_projective(&gs[..n + 1]), 8);
+    let c_t = PolynomialCommitment::coeffs_to_commitment(&t_coeffs, &msm_precomputation, h, false);
+    ensure!(c_t.to_affine() == proof.c_t, "Incorrect table commitment");
+
+    let challs = proof.get_challenges()?;
+    let PlookupProofChallenge {
+        beta,
+        gamma,
+        zeta,
+        alpha,
+        ..
+    } = challs;
+    let generator = C::ScalarField::primitive_root_of_unity(log2_strict(n + 1));
+    let beta1 = challs.beta + C::ScalarField::ONE;
+    let gamma_beta1 = challs.gamma * beta1;
+
+    let vanishing_z1_term =
+        eval_l_i(n + 1, 0, generator, zeta) * (proof.openings.z.local - C::ScalarField::ONE);
+    let vanishing_shift_term = (zeta - generator.exp_usize(n))
+        * proof.openings.z.local
+        * beta1
+        * (gamma + proof.openings.f.local)
+        * (gamma_beta1 + proof.openings.t.local + beta * proof.openings.t.right)
+        - (zeta - generator.exp_usize(n))
+            * proof.openings.z.right
+            * (gamma_beta1 + proof.openings.h1.local + beta * proof.openings.h1.right)
+            * (gamma_beta1 + proof.openings.h2.local + beta * proof.openings.h2.right);
+    let eval_last = eval_l_i(n + 1, n, generator, zeta);
+    let vanishing_hs_term = eval_last * (proof.openings.h1.local - proof.openings.h2.right);
+    let vanishing_last_term = eval_last * (proof.openings.z.local - C::ScalarField::ONE);
+
+    let numerator = reduce_with_powers(
+        &[
+            vanishing_z1_term,
+            vanishing_shift_term,
+            vanishing_hs_term,
+            vanishing_last_term,
+        ],
+        alpha,
+    );
+    let denominator = zeta.exp_usize(n + 1) - C::ScalarField::ONE;
+
+    let purpoted_quotient_opening = numerator / denominator;
+
+    ensure!(
+        purpoted_quotient_opening == proof.openings.quotient.local,
+        "Incorrect quotient opening"
+    );
+
+    let c_all = vec![
+        proof.c_f,
+        proof.c_t,
+        proof.c_h1,
+        proof.c_h2,
+        proof.c_z,
+        proof.c_quotient,
+    ];
+
+    ensure!(
+        verify_all_ipas(
+            &c_all,
+            generator,
+            u_curve,
+            h,
+            proof,
+            challs.u,
+            challs.v,
+            challs.u_scaling,
+            challs.zeta,
+            &challs.halo_us,
+            challs.schnorr_challenge,
+            SECURITY_BITS,
+        ),
+        "Invalid IPA proof."
+    );
+
+    // TODO: Add option to verify `halo_g` point.
+    Ok(())
+}
+
+/// Verify all IPAs in the given proof using a reduction to a single polynomial.
+fn verify_all_ipas<C: HaloCurve>(
+    c_all: &[AffinePoint<C>],
+    subgroup_generator_n: C::ScalarField,
+    u_curve: AffinePoint<C>,
+    pedersen_h: AffinePoint<C>,
+    proof: &PlookupProof<C>,
+    u: C::ScalarField,
+    v: C::ScalarField,
+    u_scaling: C::ScalarField,
+    zeta: C::ScalarField,
+    halo_us: &[C::ScalarField],
+    schnorr_challenge: C::ScalarField,
+    security_bits: usize,
+) -> bool {
+    // Reduce all polynomial commitments to a single one, i.e. a random combination of them.
+    let powers_of_u = powers(u, c_all.len());
+    let actual_scalars = powers_of_u
+        .iter()
+        .map(|u_pow| halo_n::<C>(&u_pow.to_canonical_bool_vec()[..security_bits]))
+        .collect::<Vec<_>>();
+    let precomputation = msm_precompute(&AffinePoint::batch_to_projective(&c_all), 8);
+    let c_reduction = msm_execute_parallel(&precomputation, &actual_scalars);
+
+    // For each opening set, we do a similar reduction, using the actual scalars above.
+    let opening_set_reductions = vec![
+        C::ScalarField::inner_product(&actual_scalars, &proof.openings.local()),
+        C::ScalarField::inner_product(&actual_scalars, &proof.openings.right()),
+    ];
+
+    // Then, we reduce the above opening set reductions to a single value.
+    let reduced_opening = reduce_with_powers(&opening_set_reductions, v);
+
+    let u_prime =
+        halo_n_mul(&u_scaling.to_canonical_bool_vec()[..security_bits], u_curve).to_projective();
+
+    let points = [zeta, zeta * subgroup_generator_n];
+    let halo_bs = points
+        .iter()
+        .map(|&p| halo_g(p, &halo_us))
+        .collect::<Vec<_>>();
+    let halo_b = reduce_with_powers(&halo_bs, v);
+    verify_ipa::<C>(
+        &proof.halo_proof.halo_l,
+        &proof.halo_proof.halo_r,
+        proof.halo_proof.halo_g,
+        c_reduction,
+        reduced_opening,
+        halo_b,
+        halo_us,
+        u_prime,
+        pedersen_h,
+        schnorr_challenge,
+        proof.halo_proof.schnorr_proof,
+    )
+}

--- a/plookup/tests/plookup.rs
+++ b/plookup/tests/plookup.rs
@@ -1,0 +1,160 @@
+use anyhow::Result;
+use num::{BigUint, Integer};
+use plonky::{biguint_to_field, field_to_biguint, Curve, Field, Tweedledee};
+use plookup::plookup::prove;
+use plookup::table::Table;
+use plookup::verifier::verify;
+use rand::seq::SliceRandom;
+use rand::{thread_rng, Rng};
+
+fn add<F: Field>(a: [F; 2]) -> F {
+    a[0] + a[1]
+}
+
+fn add_4_bits<F: Field>(a: [F; 2]) -> F {
+    biguint_to_field(
+        (field_to_biguint(a[0]) + field_to_biguint(a[1])).mod_floor(&BigUint::from(1usize << 4)),
+    )
+}
+
+fn xor_4_bits<F: Field>(a: [F; 2]) -> F {
+    biguint_to_field(
+        (field_to_biguint(a[0]) ^ field_to_biguint(a[1])).mod_floor(&BigUint::from(1usize << 4)),
+    )
+}
+
+fn mul_3_times_3_bits<F: Field>(a: [F; 3]) -> F {
+    biguint_to_field(
+        (field_to_biguint(a[0]) * field_to_biguint(a[1]) * field_to_biguint(a[2]))
+            .mod_floor(&BigUint::from(1usize << 3)),
+    )
+}
+
+#[test]
+fn test_plookup() -> Result<()> {
+    type C = Tweedledee;
+    type SF = <C as Curve>::ScalarField;
+    let mut rng = thread_rng();
+    let n = 15;
+    let t = (0..rng.gen_range(1, n / 2))
+        .map(|_| SF::rand())
+        .collect::<Vec<_>>();
+    let f = (0..n)
+        .map(|_| *t.choose(&mut rng).unwrap())
+        .collect::<Vec<_>>();
+    let proof = prove::<C>(&f, &t)?;
+    verify(&t, &proof)?;
+    Ok(())
+}
+
+#[test]
+fn test_plookup_table() -> Result<()> {
+    type C = Tweedledee;
+    type SF = <C as Curve>::ScalarField;
+    let mut rng = thread_rng();
+    let n = 15;
+    const WIDTH: usize = 10;
+    let t = Table(
+        (0..rng.gen_range(1, n / 2))
+            .map(|_| {
+                let mut arr = [SF::ZERO; WIDTH];
+                (0..WIDTH).for_each(|i| arr[i] = SF::rand());
+                arr
+            })
+            .collect::<Vec<_>>(),
+    );
+    let f = Table(
+        (0..n)
+            .map(|_| *t.0.choose(&mut rng).unwrap())
+            .collect::<Vec<_>>(),
+    );
+    let proof = t.prove_row::<C>(&f)?;
+    t.verify(&proof)?;
+    Ok(())
+}
+#[test]
+fn test_plookup_function() -> Result<()> {
+    const WIDTH: usize = 3;
+    type C = Tweedledee;
+    type SF = <C as Curve>::ScalarField;
+    let mut rng = thread_rng();
+    let n: usize = 15;
+    let domain = (0..rng.gen_range(1, n / 2))
+        .map(|_| [SF::rand(), SF::rand()])
+        .collect::<Vec<_>>();
+    let t = Table::<SF, WIDTH>::from_function(&add, &domain);
+    let f = Table(
+        (0..n)
+            .map(|_| *t.0.choose(&mut rng).unwrap())
+            .collect::<Vec<_>>(),
+    );
+    let proof = t.prove_row::<C>(&f)?;
+    t.verify(&proof)?;
+    Ok(())
+}
+
+#[test]
+fn test_add_4_bits() -> Result<()> {
+    const WIDTH: usize = 3;
+    const BITS: usize = 4;
+    type C = Tweedledee;
+    type SF = <C as Curve>::ScalarField;
+    let mut rng = thread_rng();
+    let n: usize = 15;
+    let domain = (0..(1 << BITS))
+        .map(|i| SF::from_canonical_usize(i))
+        .collect::<Vec<_>>();
+    let t = Table::<SF, WIDTH>::from_function_cartesian(&add_4_bits::<SF>, &domain);
+    let f = Table(
+        (0..n)
+            .map(|_| *t.0.choose(&mut rng).unwrap())
+            .collect::<Vec<_>>(),
+    );
+    let proof = t.prove_row::<C>(&f)?;
+    t.verify(&proof)?;
+    Ok(())
+}
+
+#[test]
+fn test_xor_4_bits() -> Result<()> {
+    const WIDTH: usize = 3;
+    const BITS: usize = 4;
+    type C = Tweedledee;
+    type SF = <C as Curve>::ScalarField;
+    let mut rng = thread_rng();
+    let n: usize = 15;
+    let domain = (0..(1 << BITS))
+        .map(|i| SF::from_canonical_usize(i))
+        .collect::<Vec<_>>();
+    let t = Table::<SF, WIDTH>::from_function_cartesian(&xor_4_bits::<SF>, &domain);
+    let f = Table(
+        (0..n)
+            .map(|_| *t.0.choose(&mut rng).unwrap())
+            .collect::<Vec<_>>(),
+    );
+    let proof = t.prove_row::<C>(&f)?;
+    t.verify(&proof)?;
+    Ok(())
+}
+
+#[test]
+fn test_mul_3_bits() -> Result<()> {
+    const WIDTH: usize = 4;
+    const BITS: usize = 3;
+    type C = Tweedledee;
+    type SF = <C as Curve>::ScalarField;
+    let mut rng = thread_rng();
+    let n: usize = 15;
+    let domain = (0..(1 << BITS))
+        .map(|i| SF::from_canonical_usize(i))
+        .collect::<Vec<_>>();
+    let t = Table::<SF, WIDTH>::from_function_cartesian(&mul_3_times_3_bits::<SF>, &domain);
+    let f = Table(
+        (0..n)
+            .map(|_| *t.0.choose(&mut rng).unwrap())
+            .collect::<Vec<_>>(),
+    );
+    let proof = t.prove_row::<C>(&f)?;
+    t.verify(&proof)?;
+    Ok(())
+}


### PR DESCRIPTION
Added Plookup support. Currently this can be used to prove that a set of committed values is a subset of a public lookup table. We will then be able to integrate this into Plonky and add these checks for some circuits where a lookup table can save lots of gates, e.g., bit operations.   