### PR TITLE
Circuit code for bigint and foreign field arithmetic

### DIFF
--- a/src/circuit_builder_bigint.rs
+++ b/src/circuit_builder_bigint.rs
@@ -1,0 +1,471 @@
+use crate::{field_to_biguint, HaloCurve, CircuitBuilder, Target, OrderingTarget, util::pad_to_multiple_usize, Base4SumGate, Field, WitnessGenerator, PartialWitness, BoundedTarget, biguint_to_field};
+use num::{One, BigUint, Zero, Integer};
+use crate::util::ceil_div_usize;
+
+/// We use 86-bit limbs so that
+/// - Any ~256 bit field element can be encoded as three limbs
+/// - Each limb product will take at most 172 bits
+/// - If our native field size is at least ~256 bits, we can accumulate many limb products witout
+///   overflowing the native field
+pub(crate) const LIMB_DIBITS: usize = 43;
+pub(crate) const LIMB_BITS: usize = LIMB_DIBITS * 2;
+
+/// Targets representing an unsigned big integer.
+#[derive(Clone)]
+pub struct BigIntTarget {
+    pub limbs: Vec<Target>,
+    /// An inclusive upper bound on this number.
+    pub max: BigUint,
+}
+
+impl BigIntTarget {
+    pub fn new_bounded(limbs: Vec<Target>, max: BigUint) -> Self {
+        Self { limbs, max }
+    }
+
+    pub fn new_unbounded(limbs: Vec<Target>) -> Self {
+        let bits = LIMB_BITS * limbs.len();
+        let one = BigUint::one();
+        let max = (&one << bits) - one;
+        Self { limbs, max }
+    }
+
+    pub fn zero() -> Self {
+        Self {
+            limbs: Vec::new(),
+            max: BigUint::zero(),
+        }
+    }
+
+    pub fn num_limbs(&self) -> usize {
+        self.limbs.len()
+    }
+
+    pub fn get_limb(&self, index: usize) -> Target {
+        self.limbs[index]
+    }
+
+    pub fn get_bounded_limb(&self, index: usize) -> BoundedTarget {
+        // We shift self.max to get the max value of this limb AND any more significant limbs.
+        let max_high_limbs = &self.max >> LIMB_BITS * index;
+        let max_any_limb = (BigUint::one() << LIMB_BITS) - BigUint::one();
+        let max_this_limb = max_high_limbs.min(max_any_limb);
+        BoundedTarget { target: self.get_limb(index), max: max_this_limb }
+    }
+
+    fn get_bounded_limb_or_default(&self, index: usize, default: BoundedTarget) -> BoundedTarget {
+        if index < self.num_limbs() {
+            self.get_bounded_limb(index)
+        } else {
+            default
+        }
+    }
+
+    /// Return `(first, rest)`, where `first` is this bigint's least significant limb, and `rest` is
+    /// a bigint consisting of the remaining limbs.
+    fn split_smallest_limb(&self) -> (Target, Self) {
+        let first = self.get_limb(0);
+        let rest_limbs = self.limbs[1..].to_vec();
+        let rest_max = &self.max >> LIMB_BITS;
+        let rest = BigIntTarget { limbs: rest_limbs, max: rest_max };
+        (first, rest)
+    }
+}
+
+impl From<BoundedTarget> for BigIntTarget {
+    fn from(bounded_target: BoundedTarget) -> Self {
+        Self {
+            limbs: vec![bounded_target.target],
+            max: bounded_target.max,
+        }
+    }
+}
+
+pub(crate) fn biguint_to_limbs<F: Field>(biguint: &BigUint) -> Vec<F> {
+    let num_limbs = ceil_div_usize(biguint.bits(), LIMB_BITS);
+    let base = BigUint::one() << LIMB_BITS;
+    (0..num_limbs)
+        .map(|i| biguint_to_field((biguint >> i * LIMB_BITS) % &base))
+        .collect()
+}
+
+impl<C: HaloCurve> CircuitBuilder<C> {
+    pub fn add_virtual_bigint_target(&mut self, max: &BigUint, validate: bool) -> BigIntTarget {
+        let num_limbs = ceil_div_usize(max.bits(), LIMB_BITS);
+        let limbs = self.add_virtual_targets(num_limbs);
+
+        if validate {
+            // Check that we have a valid bigint encoding, with each limb being in the proper range.
+            for &limb in &limbs {
+                self.assert_dibit_length(limb, LIMB_DIBITS);
+            }
+        }
+
+        BigIntTarget { limbs, max: max.clone() }
+    }
+
+    pub fn constant_bigint(&mut self, value: &BigUint) -> BigIntTarget {
+        let limbs = biguint_to_limbs(value)
+            .into_iter()
+            .map(|limb| self.constant_wire(limb))
+            .collect();
+        BigIntTarget { limbs, max: value.clone() }
+    }
+
+    pub fn bigint_cmp(&mut self, x: &BigIntTarget, y: &BigIntTarget) -> OrderingTarget {
+        // We test each pair of limbs for equality. Then we find the most significant pair that
+        // does not match, and compare those limbs. A roughly similar approach was described in
+        // https://github.com/mir-protocol/r1cs-workshop/blob/master/workshop.pdf
+
+        // Zero-pad the inputs if needed.
+        let num_limbs = x.limbs.len().max(y.limbs.len());
+        let x = self.bigint_pad_limbs(x, num_limbs);
+        let y = self.bigint_pad_limbs(y, num_limbs);
+
+        // These track the most significant pair of limbs that differed, if any.
+        let mut x_diff = self.zero_wire();
+        let mut y_diff = self.zero_wire();
+
+        for i in 0..num_limbs {
+            let x_i = x.limbs[i];
+            let y_i = y.limbs[i];
+            let equal = self.is_equal(x_i, y_i);
+            x_diff = self.select(equal, x_diff, x_i);
+            y_diff = self.select(equal, y_diff, y_i);
+        }
+
+        self.limb_cmp(x_diff, y_diff)
+    }
+
+    fn limb_cmp(&mut self, x: Target, y: Target) -> OrderingTarget {
+        let ordering = self.add_virtual_ordering_target(true);
+        let OrderingTarget { gt, eq, lt } = ordering;
+        self.add_ordering_generator(ordering, x, y);
+
+        // Check that eq == (x == y).
+        let is_equal = self.is_equal(x, y);
+        self.copy(eq, is_equal);
+
+        // Now we want to check that if lt == 1, x <= y, and if gt == 1, x >= y.
+        // (Strict equality is not required here since we already checked the eq case.)
+        // We will do this by computing
+        //     r = lt * (y - x) + gt * (x - y)
+        //       = lt * (y - x) - gt * (y - x)
+        // and range checking r to ensure that no underflow occurs.
+        let delta = self.sub(y, x);
+        let gt_delta = self.mul(gt, delta);
+        let r = self.mul_sub(lt, delta, gt_delta);
+
+        // We have some flexibility in what upper bound to use for the range check. The max
+        // number of dibits must be at least LIMB_DIBITS, since r can legitimately be that large
+        // without underflow. We will pad to a multiple of Base4Gate::NUM_LIMBS, since
+        // assert_dibit_length is more efficient in that case. We will still detect any underflow,
+        // since that would result in r consuming at least roughly F_dibits - LIMB_DIBITS, which
+        // for any reasonably large field, will exceed pad(LIMB_DIBITS).
+        let max_dibits = pad_to_multiple_usize(LIMB_DIBITS, Base4SumGate::<C>::NUM_LIMBS);
+        self.assert_dibit_length(r, max_dibits);
+
+        ordering
+    }
+
+    pub fn bigint_add(&mut self, x: &BigIntTarget, y: &BigIntTarget) -> BigIntTarget {
+        self.bigint_add_many(&[x.clone(), y.clone()])
+    }
+
+    pub fn bigint_add_many(&mut self, terms: &[BigIntTarget]) -> BigIntTarget {
+        let num_limbs = terms.iter()
+            .map(BigIntTarget::num_limbs)
+            .max().expect("No operands");
+
+        let mut carry: BoundedTarget = self.zero_bounded_target();
+        let mut result_limbs = Vec::new();
+        for i in 0..num_limbs {
+            let mut bounded_limbs = vec![carry];
+            for term in terms {
+                if term.num_limbs() > i {
+                    bounded_limbs.push(term.get_bounded_limb(i));
+                }
+            }
+
+            let sum_of_limbs = self.sum_limbs(&bounded_limbs);
+
+            // Unless the number of terms is astronomical, we should have two limbs at most.
+            assert!(sum_of_limbs.num_limbs() <= 2);
+
+            // The first limb (or zero if there are no limbs) becomes a limb of the result.
+            result_limbs.push(
+                sum_of_limbs.limbs.get(0).cloned()
+                    .unwrap_or(self.zero_wire()));
+
+            // The second limb (or zero if there isn't one) becomes our carry.
+            carry = sum_of_limbs.get_bounded_limb_or_default(
+                1, self.zero_bounded_target());
+        }
+
+        if !carry.max.is_zero() {
+            result_limbs.push(carry.target);
+        }
+
+        let max = terms.iter().map(|t| &t.max).sum();
+        BigIntTarget { limbs: result_limbs, max }
+    }
+
+    fn sum_limbs(&mut self, limbs: &[BoundedTarget]) -> BigIntTarget {
+        let nonzero_limbs: Vec<BoundedTarget> = limbs.iter()
+            .cloned()
+            .filter(|l| !l.max.is_zero())
+            .collect();
+
+        if nonzero_limbs.is_empty() {
+            return BigIntTarget::zero();
+        }
+
+        if nonzero_limbs.len() == 1 {
+            return nonzero_limbs[0].clone().into();
+        }
+
+        // Convert to a Vec of unbounded limbs.
+        let nonzero_limbs: Vec<Target> = nonzero_limbs.iter()
+            .map(|bounded_limb| bounded_limb.target)
+            .collect();
+
+        // Compute an overall bound based on each limb's bound.
+        let mut max = BigUint::zero();
+        for limb in limbs {
+            max += &limb.max;
+        }
+
+        let sum = self.add_many(&nonzero_limbs);
+        self.target_to_bigint(&BoundedTarget { target: sum, max })
+    }
+
+    /// Split the given bounded target into a `BigIntTarget`.
+    fn target_to_bigint(&mut self, input: &BoundedTarget) -> BigIntTarget {
+        struct SplitGenerator {
+            input: BoundedTarget,
+            output: BigIntTarget,
+        }
+
+        impl<F: Field> WitnessGenerator<F> for SplitGenerator {
+            fn dependencies(&self) -> Vec<Target> {
+                vec![self.input.target]
+            }
+
+            fn generate(&self, _constants: &Vec<Vec<F>>, witness: &PartialWitness<F>) -> PartialWitness<F> {
+                let value = witness.get_target(self.input.target);
+
+                let mut result = PartialWitness::new();
+                result.set_bigint_target(&self.output, &field_to_biguint(value));
+                result
+            }
+        }
+
+        let output = self.add_virtual_bigint_target(&input.max, true);
+        self.add_generator(SplitGenerator { input: input.clone(), output: output.clone() });
+
+        // Check that a weighted sum of the limbs matches the original input.
+        let joined = self.bigint_to_target(&output);
+        self.copy(joined.target, input.target);
+
+        output
+    }
+
+    /// Join a `BigIntTarget` into a `BoundedTarget`.
+    fn bigint_to_target(&mut self, bigint: &BigIntTarget) -> BoundedTarget {
+        let mut sum = self.zero_wire();
+        let limb_multiplier = self.constant_wire(
+            C::ScalarField::TWO.exp_usize(LIMB_BITS));
+        for &limb in bigint.limbs.iter().rev() {
+            sum = self.mul_add(sum, limb_multiplier, limb);
+        }
+        BoundedTarget { target: sum, max: bigint.max.clone() }
+    }
+
+    pub fn bigint_mul(&mut self, x: &BigIntTarget, y: &BigIntTarget) -> BigIntTarget {
+        let x_n = x.num_limbs();
+        let y_n = y.num_limbs();
+
+        let mut result_digits = Vec::new();
+        let mut carry: BigIntTarget = BigIntTarget::zero();
+
+        // We want to enumerate the cartesian product of x's and y's limbs, ordered from least
+        // significant to most significant. We will do so by enumerating the possible "shifts",
+        // measured in limbs. We will add up the (shifted) intermediate products as we go.
+        for shift in 0..=(x_n + y_n - 2) {
+            let mut sum_of_limb_products = self.bigint_to_target(&carry);
+
+            // We want to enumerate valid pairs of indices such that x_index + y_index = shift.
+            for x_index in 0..x_n {
+                for y_index in 0..y_n {
+                    if x_index + y_index == shift {
+                        let x_limb = x.get_bounded_limb(x_index);
+                        let y_limb = y.get_bounded_limb(y_index);
+                        sum_of_limb_products = self.bounded_mul_add(
+                            &x_limb, &y_limb, &sum_of_limb_products);
+                    }
+                }
+            }
+
+            let sum_of_limb_products_bigint = self.target_to_bigint(&sum_of_limb_products);
+            let (first, rest) = sum_of_limb_products_bigint.split_smallest_limb();
+            result_digits.push(first);
+            carry = rest;
+        }
+
+        // Add any remaining carry digits.
+        for i in 0..carry.num_limbs() {
+            result_digits.push(carry.get_limb(i));
+        }
+
+        let max = &x.max * &y.max;
+        BigIntTarget { limbs: result_digits, max }
+    }
+
+    pub fn bigint_div(&mut self, x: &BigIntTarget, y: &BigIntTarget) -> BigIntTarget {
+        let (div, _rem) = self.bigint_div_rem(x, y);
+        div
+    }
+
+    pub fn bigint_rem(&mut self, x: &BigIntTarget, y: &BigIntTarget) -> BigIntTarget {
+        let (_div, rem) = self.bigint_div_rem(x, y);
+        rem
+    }
+
+    /// Returns `(x / y, x % y)`.
+    pub fn bigint_div_rem(
+        &mut self,
+        x: &BigIntTarget,
+        y: &BigIntTarget,
+    ) -> (BigIntTarget, BigIntTarget) {
+        struct DivRemGenerator {
+            x: BigIntTarget,
+            y: BigIntTarget,
+            div: BigIntTarget,
+            rem: BigIntTarget,
+        }
+
+        impl<F: Field> WitnessGenerator<F> for DivRemGenerator {
+            fn dependencies(&self) -> Vec<Target> {
+                [self.x.limbs.as_slice(), self.y.limbs.as_slice()].concat()
+            }
+
+            fn generate(&self, _constants: &Vec<Vec<F>>, witness: &PartialWitness<F>) -> PartialWitness<F> {
+                let x = witness.get_bigint_target(&self.x);
+                let y = witness.get_bigint_target(&self.y);
+                let (div, rem) = x.div_rem(&y);
+
+                let mut result = PartialWitness::new();
+                result.set_bigint_target(&self.div, &div);
+                result.set_bigint_target(&self.rem, &rem);
+                result
+            }
+        }
+
+        let max_rem = &y.max - BigUint::one();
+        let div = self.add_virtual_bigint_target(&x.max, true);
+        let rem = self.add_virtual_bigint_target(&max_rem, true);
+
+        self.add_generator(DivRemGenerator {
+            x: x.clone(),
+            y: y.clone(),
+            div: div.clone(),
+            rem: rem.clone(),
+        });
+
+        // Check that x = div * y + rem.
+        let div_y = self.bigint_mul(&div, &y);
+        let div_y_plus_rem = self.bigint_add(&div_y, &rem);
+        self.copy_bigint(&x, &div_y_plus_rem);
+
+        // Check that rem < y.
+        let cmp_rem_y = self.bigint_cmp(&rem, &y).lt;
+        self.assert_one(cmp_rem_y);
+
+        (div, rem)
+    }
+
+    /// Assert that the two given bigints encode the same integer.
+    pub fn copy_bigint(&mut self, lhs: &BigIntTarget, rhs: &BigIntTarget) {
+        // The number of limbs may differ, in which case we assert equality for any limb indices
+        // which are valid for both bigints, then assert that any "extra" limbs (present in one
+        // bigint but not the other) are zero.
+
+        let min_limbs = lhs.num_limbs().min(rhs.num_limbs());
+        for i in 0..min_limbs {
+            self.copy(lhs.get_limb(i), rhs.get_limb(i));
+        }
+
+        for i in min_limbs..lhs.num_limbs() {
+            self.assert_zero(lhs.get_limb(i));
+        }
+        for i in min_limbs..rhs.num_limbs() {
+            self.assert_zero(rhs.get_limb(i));
+        }
+    }
+
+    fn bigint_pad_limbs(&mut self, x: &BigIntTarget, num_limbs: usize) -> BigIntTarget {
+        assert!(x.limbs.len() <= num_limbs);
+        let mut result = x.clone();
+        result.limbs.resize(num_limbs, self.zero_wire());
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CircuitBuilder, PartialWitness, Tweedledum};
+    use num::{BigUint, FromPrimitive, Integer};
+
+    #[test]
+    fn test_bigint_add() {
+        let x_value = BigUint::from_u128(22222222222222222222222222222222222222).unwrap();
+        let y_value = BigUint::from_u128(33333333333333333333333333333333333333).unwrap();
+        let expected_z_value = &x_value + &y_value;
+
+        let mut builder = CircuitBuilder::<Tweedledum>::new(128);
+        let x = builder.constant_bigint(&x_value);
+        let y = builder.constant_bigint(&y_value);
+        let z = builder.bigint_add(&x, &y);
+        let circuit = builder.build();
+
+        let witness = circuit.generate_partial_witness(PartialWitness::new());
+        let actual_z_value = witness.get_bigint_target(&z);
+        assert_eq!(actual_z_value, expected_z_value);
+    }
+
+    #[test]
+    fn test_bigint_mul() {
+        let x_value = BigUint::from_u128(123123123123123123123123123123123123).unwrap();
+        let y_value = BigUint::from_u128(456456456456456456456456456456456456).unwrap();
+        let expected_z_value = &x_value * &y_value;
+
+        let mut builder = CircuitBuilder::<Tweedledum>::new(128);
+        let x = builder.constant_bigint(&x_value);
+        let y = builder.constant_bigint(&y_value);
+        let z = builder.bigint_mul(&x, &y);
+        let circuit = builder.build();
+
+        let witness = circuit.generate_partial_witness(PartialWitness::new());
+        let actual_z_value = witness.get_bigint_target(&z);
+        assert_eq!(actual_z_value, expected_z_value);
+    }
+
+    #[test]
+    fn test_bigint_div_rem() {
+        let x_value = BigUint::from_u128(456456456456456456456456456456456456).unwrap();
+        let y_value = BigUint::from_u128(123123123123123123123123123123123123).unwrap();
+        let (expected_div_value, expected_rem_value) = x_value.div_rem(&y_value);
+
+        let mut builder = CircuitBuilder::<Tweedledum>::new(128);
+        let x = builder.constant_bigint(&x_value);
+        let y = builder.constant_bigint(&y_value);
+        let (div, rem) = builder.bigint_div_rem(&x, &y);
+        let circuit = builder.build();
+
+        let witness = circuit.generate_partial_witness(PartialWitness::new());
+        let actual_div_value = witness.get_bigint_target(&div);
+        let actual_rem_value = witness.get_bigint_target(&rem);
+        assert_eq!(actual_div_value, expected_div_value);
+        assert_eq!(actual_rem_value, expected_rem_value);
+    }
+}

--- a/src/circuit_builder_ordering.rs
+++ b/src/circuit_builder_ordering.rs
@@ -1,0 +1,95 @@
+use crate::{HaloCurve, CircuitBuilder, Target, Field, WitnessGenerator, PartialWitness};
+use std::cmp::Ordering;
+
+#[derive(Copy, Clone)]
+pub struct OrderingTarget {
+    pub lt: Target,
+    pub eq: Target,
+    pub gt: Target,
+}
+
+impl<C: HaloCurve> CircuitBuilder<C> {
+    pub fn constant_ordering(&mut self, ordering: Ordering) -> OrderingTarget {
+        match ordering {
+            Ordering::Less => self.ordering_lt(),
+            Ordering::Equal => self.ordering_eq(),
+            Ordering::Greater => self.ordering_gt(),
+        }
+    }
+
+    pub fn ordering_lt(&mut self) -> OrderingTarget {
+        let _false = self.zero_wire();
+        let _true = self.one_wire();
+        OrderingTarget { lt: _true, eq: _false, gt: _false }
+    }
+
+    pub fn ordering_eq(&mut self) -> OrderingTarget {
+        let _false = self.zero_wire();
+        let _true = self.one_wire();
+        OrderingTarget { lt: _false, eq: _true, gt: _false }
+    }
+
+    pub fn ordering_gt(&mut self) -> OrderingTarget {
+        let _false = self.zero_wire();
+        let _true = self.one_wire();
+        OrderingTarget { lt: _false, eq: _false, gt: _true }
+    }
+
+    pub fn add_virtual_ordering_target(&mut self, validate: bool) -> OrderingTarget {
+        let lt = self.add_virtual_target();
+        let eq = self.add_virtual_target();
+        let gt = self.add_virtual_target();
+
+        let ordering = OrderingTarget { lt, eq, gt };
+        if validate {
+            self.ordering_assert_valid(ordering);
+        }
+        ordering
+    }
+
+    /// Adds a generator to generate `ordering` by comparing `lhs` and `rhs`.
+    pub(crate) fn add_ordering_generator(&mut self, ordering: OrderingTarget, lhs: Target, rhs: Target) {
+        struct OrderingGenerator {
+            ordering: OrderingTarget,
+            lhs: Target,
+            rhs: Target,
+        }
+
+        impl<F: Field> WitnessGenerator<F> for OrderingGenerator {
+            fn dependencies(&self) -> Vec<Target> {
+                vec![self.lhs, self.rhs]
+            }
+
+            fn generate(&self, _constants: &Vec<Vec<F>>, witness: &PartialWitness<F>) -> PartialWitness<F> {
+                let lhs = witness.get_target(self.lhs);
+                let rhs = witness.get_target(self.rhs);
+
+                let mut result = PartialWitness::new();
+                result.set_ordering_target(self.ordering, lhs.cmp(&rhs));
+                result
+            }
+        }
+
+        self.add_generator(OrderingGenerator { ordering, lhs, rhs });
+    }
+
+    pub fn ordering_assert_valid(&mut self, ordering: OrderingTarget) {
+        let OrderingTarget { lt, eq, gt } = ordering;
+
+        self.assert_binary(lt);
+        self.assert_binary(eq);
+        self.assert_binary(gt);
+
+        // Two of the three targets must be zero, so each product must be zero.
+        let lt_eq = self.mul(lt, eq);
+        let lt_gt = self.mul(lt, gt);
+        let eq_gt = self.mul(eq, gt);
+        self.assert_zero(lt_eq);
+        self.assert_zero(lt_gt);
+        self.assert_zero(eq_gt);
+
+        // The remaining target must be one, so the sum must be one.
+        let sum = self.add_many(&[lt, eq, gt]);
+        self.assert_one(sum);
+    }
+}

--- a/src/foreign_field.rs
+++ b/src/foreign_field.rs
@@ -1,0 +1,103 @@
+use crate::{HaloCurve, CircuitBuilder, BigIntTarget, Field, field_to_biguint};
+use num::{BigUint, One};
+
+/// Represents an element of a field other than the native field.
+#[derive(Clone)]
+pub struct ForeignFieldTarget {
+    pub value: BigIntTarget,
+}
+
+impl ForeignFieldTarget {
+    pub fn zero() -> Self {
+        ForeignFieldTarget { value: BigIntTarget::zero() }
+    }
+}
+
+impl<C: HaloCurve> CircuitBuilder<C> {
+    pub fn constant_foreign_field<FF: Field>(&mut self, constant: FF) -> ForeignFieldTarget {
+        let value = self.constant_bigint(&field_to_biguint(constant));
+        ForeignFieldTarget { value }
+    }
+
+    pub fn foreign_field_add_many<FF: Field>(
+        &mut self,
+        terms: &[ForeignFieldTarget],
+    ) -> ForeignFieldTarget {
+        let term_values = terms.iter()
+            .map(|ff| ff.value.clone())
+            .collect::<Vec<_>>();
+        let sum = self.bigint_add_many(&term_values);
+        self.reduce::<FF>(&sum)
+    }
+
+    pub fn foreign_field_add<FF: Field>(
+        &mut self,
+        x: &ForeignFieldTarget,
+        y: &ForeignFieldTarget,
+    ) -> ForeignFieldTarget {
+        self.foreign_field_add_many::<FF>(&[x.clone(), y.clone()])
+    }
+
+    pub fn foreign_field_mul<FF: Field>(
+        &mut self,
+        lhs: &ForeignFieldTarget,
+        rhs: &ForeignFieldTarget,
+    ) -> ForeignFieldTarget {
+        let product = self.bigint_mul(&lhs.value, &rhs.value);
+        self.reduce::<FF>(&product)
+    }
+
+    /// Returns `x % |FF|` as a `ForeignFieldTarget`.
+    fn reduce<FF: Field>(&mut self, x: &BigIntTarget) -> ForeignFieldTarget {
+        let order = field_to_biguint(FF::NEG_ONE) + BigUint::one();
+        let order_target = self.constant_bigint(&order);
+        let value = self.bigint_rem(&x, &order_target);
+        ForeignFieldTarget { value }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CircuitBuilder, PartialWitness, Tweedledum, Field, Curve};
+    use num::{BigUint, FromPrimitive};
+
+    #[test]
+    fn test_foreign_field_add() {
+        type C = Tweedledum;
+        type FF = <C as Curve>::ScalarField;
+
+        let x_value = FF::rand();
+        let y_value = FF::rand();
+        let expected_z_value = x_value + y_value;
+
+        let mut builder = CircuitBuilder::<C>::new(128);
+        let x = builder.constant_foreign_field(x_value);
+        let y = builder.constant_foreign_field(y_value);
+        let z = builder.foreign_field_add::<FF>(&x, &y);
+        let circuit = builder.build();
+
+        let witness = circuit.generate_partial_witness(PartialWitness::new());
+        let actual_z_value: FF = witness.get_foreign_field_target(&z);
+        assert_eq!(actual_z_value, expected_z_value);
+    }
+
+    #[test]
+    fn test_foreign_field_mul() {
+        type C = Tweedledum;
+        type FF = <C as Curve>::ScalarField;
+
+        let x_value = FF::rand();
+        let y_value = FF::rand();
+        let expected_z_value = x_value * y_value;
+
+        let mut builder = CircuitBuilder::<C>::new(128);
+        let x = builder.constant_foreign_field(x_value);
+        let y = builder.constant_foreign_field(y_value);
+        let z = builder.foreign_field_mul::<FF>(&x, &y);
+        let circuit = builder.build();
+
+        let witness = circuit.generate_partial_witness(PartialWitness::new());
+        let actual_z_value: FF = witness.get_foreign_field_target(&z);
+        assert_eq!(actual_z_value, expected_z_value);
+    }
+}

--- a/src/gates/base_4_sum.rs
+++ b/src/gates/base_4_sum.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::gates::Gate;
-use crate::{CircuitBuilder, Curve, Field, HaloCurve, PartialWitness, Target, WitnessGenerator};
+use crate::{CircuitBuilder, Curve, Field, HaloCurve, PartialWitness, Target, WitnessGenerator, NUM_ROUTED_WIRES, NUM_WIRES};
 
 /// A gate for accumulating base-4 limbs.
 pub struct Base4SumGate<C: Curve> {
@@ -19,8 +19,13 @@ impl<C: HaloCurve> Base4SumGate<C> {
 
     pub const WIRE_ACC_OLD: usize = 0;
     pub const WIRE_ACC_NEW: usize = 1;
-    pub const WIRE_LIMB_0: usize = 2;
-    pub const NUM_LIMBS: usize = 7;
+    pub const NUM_LIMBS: usize = NUM_WIRES - 2;
+    pub const NUM_ROUTED_LIMBS: usize = NUM_ROUTED_WIRES - 2;
+
+    /// Returns the index of the `i`th limb wire.
+    pub fn wire_limb(i: usize) -> usize {
+        2 + i
+    }
 }
 
 impl<C: HaloCurve> Gate<C> for Base4SumGate<C> {
@@ -37,7 +42,7 @@ impl<C: HaloCurve> Gate<C> for Base4SumGate<C> {
         let acc_old = local_wire_values[Self::WIRE_ACC_OLD];
         let acc_new = local_wire_values[Self::WIRE_ACC_NEW];
         let limbs: Vec<C::ScalarField> = (0..Self::NUM_LIMBS)
-            .map(|i| local_wire_values[Self::WIRE_LIMB_0 + i])
+            .map(|i| local_wire_values[Self::wire_limb(i)])
             .collect();
 
         let mut computed_acc_new = acc_old;
@@ -68,7 +73,7 @@ impl<C: HaloCurve> Gate<C> for Base4SumGate<C> {
         let acc_old = local_wire_values[Self::WIRE_ACC_OLD];
         let acc_new = local_wire_values[Self::WIRE_ACC_NEW];
         let limbs: Vec<Target> = (0..Self::NUM_LIMBS)
-            .map(|i| local_wire_values[Self::WIRE_LIMB_0 + i])
+            .map(|i| local_wire_values[Self::wire_limb(i)])
             .collect();
 
         let mut computed_acc_new = acc_old;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,13 @@
 
 pub use bigint::*;
 pub use circuit_builder::*;
+pub use circuit_builder_bigint::*;
+pub use circuit_builder_ordering::*;
 pub use conversions::*;
 pub use curve::*;
 pub use fft::*;
 pub use field::*;
+pub use foreign_field::*;
 pub use gates::*;
 pub use hash_to_curve::*;
 pub use mds::*;
@@ -28,10 +31,13 @@ pub use witness::*;
 
 mod bigint;
 mod circuit_builder;
+mod circuit_builder_bigint;
+mod circuit_builder_ordering;
 mod conversions;
 mod curve;
 mod fft;
 mod field;
+mod foreign_field;
 mod gates;
 pub mod halo;
 mod hash_to_curve;

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,4 +1,5 @@
 use crate::{NUM_ROUTED_WIRES, NUM_WIRES};
+use num::BigUint;
 
 /// A sort of proxy wire, in the context of routing and witness generation. It is not an actual
 /// witness element (i.e. wire) itself, but it can be copy-constrained to wires, listed as a
@@ -28,6 +29,14 @@ impl Wire {
 pub enum Target {
     VirtualTarget(VirtualTarget),
     Wire(Wire),
+}
+
+#[derive(Clone)]
+/// A `Target` with a (inclusive) known upper bound.
+pub struct BoundedTarget {
+    pub target: Target,
+    /// An inclusive upper bound on this number.
+    pub max: BigUint,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,10 @@ pub(crate) fn ceil_div_usize(a: usize, b: usize) -> usize {
     (a + b - 1) / b
 }
 
+pub(crate) fn pad_to_multiple_usize(a: usize, b: usize) -> usize {
+    ceil_div_usize(a, b) * b
+}
+
 /// Computes `ceil(log_2(n))`.
 pub(crate) fn log2_ceil(n: usize) -> usize {
     n.next_power_of_two().trailing_zeros() as usize

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -440,8 +440,8 @@ fn test_base_4_sum() -> Result<()> {
         }),
     );
 
-    let t_limbs = (B4::WIRE_LIMB_0..B4::WIRE_LIMB_0 + B4::NUM_LIMBS) //(B4::WIRE_LIMB_0..B4::WIRE_LIMB_0 + B4::NUM_LIMBS)
-        .map(|input| Target::Wire(Wire { gate: index, input }))
+    let t_limbs = (0..B4::NUM_LIMBS)
+        .map(|i| Target::Wire(Wire { gate: index, input: B4::wire_limb(i) }))
         .collect::<Vec<_>>();
 
     let circuit = builder.build();


### PR DESCRIPTION
Currently foreign field addition takes ~400 gates and multiplication takes ~600 gates, most of which is range checking via `Base4SumGate`. The reduction is the most expensive part, so batch operations (like adding many products of foreign field elements) should be much more efficient, since they can do a single reduction. There's definitely room for improvement if we want to optimize further; I've just been focused on simplicity. Of couse plookup could also be integrated for much cheaper range checking.

A few design questions that came up:

- How should we fit bounded types into the type hierarchy? Originally I had `Target`, `BoundedTarget`, `BigIntTarget`, and `BoundedBigIntTarget`. It was getting a bit cluttered with bounded and unbounded versions of various methods, so I merged the latter two (so `BigIntTarget` always has a bound; it just might be a trivial bound based on the number of limbs). Ideally I'd like to also merge `Target` and `BoundedTarget`, but I don't see a clean way to do that since `Target` is an enum.

- Should we try to keep `num` types like `BigUInt` out of the public API? Originally I was aiming to, since other projects might be using a different version of `num`, and mixing versions can lead to confusing errors. But if we make `BigIntTarget` public, then we essentially need `BigUInt` in the public API.

- Should `ForeignField` be parameterized with a `Field` type? It wouldn't technically be used, so we'd need to add it with `PhantomData`, but it might increase type safety somewhat, ensuring that different foreign fields can't be added or what not. (The same applies to `AffinePointTarget`.)