### PR TITLE
New polynomial API

### DIFF
--- a/plookup/src/lib.rs
+++ b/plookup/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(incomplete_features)]
 #![feature(const_generics)]
 
 mod openings;

--- a/plookup/src/openings.rs
+++ b/plookup/src/openings.rs
@@ -1,5 +1,4 @@
-use plonky::plonk_util::eval_poly;
-use plonky::Field;
+use plonky::{Field, Polynomial};
 
 pub struct Opening<F: Field> {
     pub local: F,
@@ -68,26 +67,22 @@ impl<F: Field> PlookupOpenings<F> {
 }
 
 pub fn open_all_polynomials<F: Field>(
-    f_coeffs: &[F],
-    t_coeffs: &[F],
-    h1_coeffs: &[F],
-    h2_coeffs: &[F],
-    z_coeffs: &[F],
-    quotient_coeffs: &[F],
+    f_poly: &Polynomial<F>,
+    t_poly: &Polynomial<F>,
+    h1_poly: &Polynomial<F>,
+    h2_poly: &Polynomial<F>,
+    z_poly: &Polynomial<F>,
+    quotient_poly: &Polynomial<F>,
     zeta: F,
     generator: F,
 ) -> PlookupOpenings<F> {
     let right = zeta * generator;
-    let f = (eval_poly(f_coeffs, zeta), eval_poly(f_coeffs, right)).into();
-    let t = (eval_poly(t_coeffs, zeta), eval_poly(t_coeffs, right)).into();
-    let h1 = (eval_poly(h1_coeffs, zeta), eval_poly(h1_coeffs, right)).into();
-    let h2 = (eval_poly(h2_coeffs, zeta), eval_poly(h2_coeffs, right)).into();
-    let z = (eval_poly(z_coeffs, zeta), eval_poly(z_coeffs, right)).into();
-    let quotient = (
-        eval_poly(quotient_coeffs, zeta),
-        eval_poly(quotient_coeffs, right),
-    )
-        .into();
+    let f = (f_poly.eval(zeta), f_poly.eval(right)).into();
+    let t = (t_poly.eval(zeta), t_poly.eval(right)).into();
+    let h1 = (h1_poly.eval(zeta), h1_poly.eval(right)).into();
+    let h2 = (h2_poly.eval(zeta), h2_poly.eval(right)).into();
+    let z = (z_poly.eval(zeta), z_poly.eval(right)).into();
+    let quotient = (quotient_poly.eval(zeta), quotient_poly.eval(right)).into();
     PlookupOpenings {
         f,
         t,

--- a/plookup/src/openings.rs
+++ b/plookup/src/openings.rs
@@ -66,6 +66,7 @@ impl<F: Field> PlookupOpenings<F> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn open_all_polynomials<F: Field>(
     f_poly: &Polynomial<F>,
     t_poly: &Polynomial<F>,

--- a/plookup/src/plookup.rs
+++ b/plookup/src/plookup.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::many_single_char_names)]
+#![allow(clippy::too_many_arguments)]
 use crate::openings::open_all_polynomials;
 use crate::proof::PlookupProof;
 use anyhow::Result;
@@ -6,7 +8,7 @@ use plonky::plonk_challenger::Challenger;
 use plonky::plonk_util::reduce_with_powers;
 use plonky::polynomial::Polynomial;
 use plonky::util::log2_strict;
-use plonky::{blake_hash_usize_to_curve, fft_precompute, fft_with_precomputation, ifft_with_precomputation_power_of_2, msm_precompute, AffinePoint, Field, HaloCurve, PolynomialCommitment};
+use plonky::{blake_hash_usize_to_curve, fft_precompute, msm_precompute, AffinePoint, Field, HaloCurve};
 
 pub const SECURITY_BITS: usize = 128;
 
@@ -34,7 +36,7 @@ pub fn prove<C: HaloCurve>(f: &[C::ScalarField], t: &[C::ScalarField]) -> Result
 
     // Curve points used in the IPA.
     let gs = (0..2 * n + 2)
-        .map(|i| blake_hash_usize_to_curve::<C>(i))
+        .map(blake_hash_usize_to_curve::<C>)
         .collect::<Vec<_>>();
     let h = blake_hash_usize_to_curve(2 * n + 2);
     let u_curve = blake_hash_usize_to_curve(2 * n + 3);

--- a/plookup/src/plookup.rs
+++ b/plookup/src/plookup.rs
@@ -46,8 +46,8 @@ pub fn prove<C: HaloCurve>(f: &[C::ScalarField], t: &[C::ScalarField]) -> Result
     // Commit to all polynomials.
     let c_f = f_poly.commit(&msm_precomputation, h, true);
     let c_t = t_poly.commit(&msm_precomputation, h, false);
-    let c_h1 = h1_poly.commit(&msm_precomputation, h, false);
-    let c_h2 = h2_poly.commit(&msm_precomputation, h, false);
+    let c_h1 = h1_poly.commit(&msm_precomputation, h, true);
+    let c_h2 = h2_poly.commit(&msm_precomputation, h, true);
 
     // Observe the commitments to get verifier challenges.
     // `beta` and `gamma` are used to construct the Plookup grand product.

--- a/plookup/src/proof.rs
+++ b/plookup/src/proof.rs
@@ -7,6 +7,7 @@ use plonky::plonk_util::halo_n;
 use plonky::{AffinePoint, Curve, Field, HaloCurve, PolynomialCommitment};
 
 // TODO: The verifier should somehow have access to `c_f`, so we can probably remove it from the proof or make it optional.
+#[allow(clippy::type_complexity)]
 pub struct PlookupProof<C: HaloCurve> {
     pub c_f: AffinePoint<C>,
     pub c_t: AffinePoint<C>,

--- a/plookup/src/verifier.rs
+++ b/plookup/src/verifier.rs
@@ -13,7 +13,7 @@ pub fn verify<C: HaloCurve>(t: &[C::ScalarField], proof: &PlookupProof<C>) -> Re
     let t = padded(t, n + 1);
     let fft_precomputation = fft_precompute(n + 1);
     let gs = (0..2 * n + 2)
-        .map(|i| blake_hash_usize_to_curve::<C>(i))
+        .map(blake_hash_usize_to_curve::<C>)
         .collect::<Vec<_>>();
     let h = blake_hash_usize_to_curve(2 * n + 2);
     let u_curve = blake_hash_usize_to_curve(2 * n + 3);

--- a/plookup/src/verifier.rs
+++ b/plookup/src/verifier.rs
@@ -4,10 +4,7 @@ use anyhow::{ensure, Result};
 use plonky::halo::verify_ipa;
 use plonky::plonk_util::{halo_g, halo_n, halo_n_mul, powers, reduce_with_powers};
 use plonky::util::log2_strict;
-use plonky::{
-    blake_hash_usize_to_curve, fft_precompute, ifft_with_precomputation_power_of_2,
-    msm_execute_parallel, msm_precompute, AffinePoint, Field, HaloCurve, PolynomialCommitment,
-};
+use plonky::{blake_hash_usize_to_curve, fft_precompute, ifft_with_precomputation_power_of_2, msm_execute_parallel, msm_precompute, AffinePoint, Field, HaloCurve, PolynomialCommitment};
 
 /// Verifies that a proof is valid for a set `t`.
 /// TODO: The verifier should have some auxiliary knowledge of `c_t`. For now, it is stored in the `proof`.

--- a/src/bigint/bigint_arithmetic.rs
+++ b/src/bigint/bigint_arithmetic.rs
@@ -1,8 +1,8 @@
 use std::cmp::Ordering;
 use std::cmp::Ordering::{Equal, Greater, Less};
 
-use rand::Rng;
 use rand::rngs::OsRng;
+use rand::Rng;
 use unroll::unroll_for_loops;
 
 /// This module provides functions for big integer arithmetic using little-endian encoded u64
@@ -103,6 +103,7 @@ pub(crate) fn sub_6_6(a: [u64; 6], b: [u64; 6]) -> [u64; 6] {
     difference
 }
 
+#[allow(dead_code)]
 #[unroll_for_loops]
 pub(crate) fn mul_4_4(a: [u64; 4], b: [u64; 4]) -> [u64; 8] {
     // Grade school multiplication. To avoid carrying at each of O(n^2) steps, we first add each
@@ -282,16 +283,31 @@ pub(crate) fn rand_range_4_from_rng<R: Rng>(limit_exclusive: [u64; 4], rng: &mut
 
 #[cfg(test)]
 mod tests {
-    use crate::{div2_6, mul_6_6};
     use crate::conversions::u64_slice_to_biguint;
+    use crate::{div2_6, mul_6_6};
 
     #[test]
     fn test_mul_6_6() {
-        let a = [11111111u64, 22222222, 33333333, 44444444, 55555555, 66666666];
-        let b = [77777777u64, 88888888, 99999999, 11111111, 22222222, 33333333];
+        let a = [
+            11111111u64,
+            22222222,
+            33333333,
+            44444444,
+            55555555,
+            66666666,
+        ];
+        let b = [
+            77777777u64,
+            88888888,
+            99999999,
+            11111111,
+            22222222,
+            33333333,
+        ];
         assert_eq!(
             u64_slice_to_biguint(&mul_6_6(a, b)),
-            u64_slice_to_biguint(&a) * u64_slice_to_biguint(&b));
+            u64_slice_to_biguint(&a) * u64_slice_to_biguint(&b)
+        );
     }
 
     #[test]
@@ -299,8 +315,22 @@ mod tests {
         assert_eq!(div2_6([40, 0, 0, 0, 0, 0]), [20, 0, 0, 0, 0, 0]);
 
         assert_eq!(
-            div2_6(
-                [15668009436471190370, 3102040391300197453, 4166322749169705801, 3518225024268476800, 11231577158546850254, 226224965816356276]),
-            [17057376755090370993, 10774392232504874534, 2083161374584852900, 1759112512134238400, 5615788579273425127, 113112482908178138]);
+            div2_6([
+                15668009436471190370,
+                3102040391300197453,
+                4166322749169705801,
+                3518225024268476800,
+                11231577158546850254,
+                226224965816356276
+            ]),
+            [
+                17057376755090370993,
+                10774392232504874534,
+                2083161374584852900,
+                1759112512134238400,
+                5615788579273425127,
+                113112482908178138
+            ]
+        );
     }
 }

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 use crate::gates::*;
 use crate::plonk_util::{coeffs_to_values_padded, commit_polynomials, halo_n, sigma_polynomials, values_to_polynomials};
 use crate::util::{ceil_div_usize, log2_strict, transpose};
-use crate::{blake_hash_base_field_to_curve, blake_hash_usize_to_curve, fft_precompute, generate_rescue_constants, msm_precompute, AffinePoint, AffinePointTarget, Circuit, Curve, CurveMsmEndoResult, CurveMulEndoResult, CurveMulOp, Field, HaloCurve, PartialWitness, Polynomial, PublicInput, Target, TargetPartitions, VirtualTarget, Wire, WitnessGenerator, NUM_CONSTANTS, NUM_WIRES};
+use crate::{blake_hash_base_field_to_curve, blake_hash_usize_to_curve, fft_precompute, generate_rescue_constants, msm_precompute, AffinePoint, AffinePointTarget, Circuit, Curve, CurveMsmEndoResult, CurveMulEndoResult, CurveMulOp, Field, HaloCurve, PartialWitness, PublicInput, Target, TargetPartitions, VirtualTarget, Wire, WitnessGenerator, NUM_CONSTANTS, NUM_WIRES};
 use std::marker::PhantomData;
 
 pub struct CircuitBuilder<C: HaloCurve> {

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use crate::gates::*;
-use crate::plonk_util::{coeffs_to_values_padded, commit_polynomials, halo_n, sigma_polynomials, values_to_polynomials};
+use crate::plonk_util::{commit_polynomials, halo_n, polynomials_to_values_padded, sigma_polynomials, values_to_polynomials};
 use crate::util::{ceil_div_usize, log2_strict, transpose};
 use crate::{blake_hash_base_field_to_curve, blake_hash_usize_to_curve, fft_precompute, generate_rescue_constants, msm_precompute, AffinePoint, AffinePointTarget, Circuit, Curve, CurveMsmEndoResult, CurveMulEndoResult, CurveMulOp, Field, HaloCurve, PartialWitness, PublicInput, Target, TargetPartitions, VirtualTarget, Wire, WitnessGenerator, NUM_CONSTANTS, NUM_WIRES};
 use std::marker::PhantomData;
@@ -1399,7 +1399,8 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         let wire_constants = transpose::<C::ScalarField>(&gate_constants);
 
         let constant_polynomials = values_to_polynomials(&wire_constants, &fft_precomputation_n);
-        let constants_8n = coeffs_to_values_padded(&constant_polynomials, &fft_precomputation_8n);
+        let constants_8n =
+            polynomials_to_values_padded(&constant_polynomials, &fft_precomputation_8n);
         let c_constants = commit_polynomials(
             constant_polynomials.as_slice(),
             &pedersen_g_msm_precomputation,
@@ -1413,7 +1414,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         // Compute S_sigma, then a commitment to it.
         let s_sigma_polynomials = values_to_polynomials(&sigma_chunks, &fft_precomputation_n);
         let s_sigma_values_8n =
-            coeffs_to_values_padded(&s_sigma_polynomials, &fft_precomputation_8n);
+            polynomials_to_values_padded(&s_sigma_polynomials, &fft_precomputation_8n);
         let c_s_sigmas = commit_polynomials(
             s_sigma_polynomials.as_slice(),
             &pedersen_g_msm_precomputation,

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -31,6 +31,12 @@ pub struct FftPrecomputation<F: Field> {
     subgroups_rev: Vec<Vec<F>>,
 }
 
+impl<F: Field> FftPrecomputation<F> {
+    pub fn size(&self) -> usize {
+        self.subgroups_rev.last().unwrap().len()
+    }
+}
+
 pub fn fft<F: Field>(coefficients: &[F]) -> Vec<F> {
     let precomputation = fft_precompute(coefficients.len());
     fft_with_precomputation(coefficients, &precomputation)

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -6,13 +6,10 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 use unroll::unroll_for_loops;
 
 use crate::nonzero_multiplicative_inverse_4;
-use crate::{
-    add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4,
-    Field,
-};
+use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
 use std::cmp::Ordering;
 use std::fmt;
-use std::fmt::{Display, Formatter, Debug};
+use std::fmt::{Debug, Display, Formatter};
 
 /// An element of the Tweedledee group's base field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
@@ -31,6 +28,7 @@ impl TweedledeeBase {
     ];
 
     /// Twice the order of the field: 57896044618658097711785492504343953926644407311908866253894167926337156677634
+    #[allow(dead_code)]
     const ORDER_X2: [u64; 4] = [
         601617200389816322,
         510387039087431059,

--- a/src/field/tweedledum_base.rs
+++ b/src/field/tweedledum_base.rs
@@ -1,7 +1,7 @@
+use rand::Rng;
 use std::cmp::Ordering::Less;
 use std::convert::TryInto;
 use std::ops::{Add, Div, Mul, Neg, Sub};
-use rand::Rng;
 
 use unroll::unroll_for_loops;
 
@@ -9,7 +9,7 @@ use crate::nonzero_multiplicative_inverse_4;
 use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
 use std::cmp::Ordering;
 use std::fmt;
-use std::fmt::{Display, Formatter, Debug};
+use std::fmt::{Debug, Display, Formatter};
 
 /// An element of the Tweedledum group's base field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
@@ -28,6 +28,7 @@ impl TweedledumBase {
     ];
 
     /// Twice the order of the field: 57896044618658097711785492504343953926644407311910638113546634138727284211714
+    #[allow(dead_code)]
     const ORDER_X2: [u64; 4] = [
         4792051847172980738,
         510387039183483763,
@@ -253,7 +254,6 @@ impl Field for TweedledumBase {
         v.len() == 4 && cmp_4_4(v[..].try_into().unwrap(), Self::ORDER) == Less
     }
 
-
     fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
         // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 = x^-1 R.
         let self_r_inv = nonzero_multiplicative_inverse_4(self.limbs, Self::ORDER);
@@ -287,7 +287,6 @@ impl PartialOrd for TweedledumBase {
     }
 }
 
-
 impl Display for TweedledumBase {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", field_to_biguint(*self))
@@ -300,11 +299,10 @@ impl Debug for TweedledumBase {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::{Field, TweedledumBase};
     use crate::test_square_root;
+    use crate::{Field, TweedledumBase};
 
     #[test]
     fn primitive_root_order() {

--- a/src/halo.rs
+++ b/src/halo.rs
@@ -1,7 +1,7 @@
 use crate::plonk_challenger::Challenger;
 use crate::plonk_util::{halo_n, halo_n_mul, powers, reduce_with_powers};
 use crate::util::log2_strict;
-use crate::{msm_execute_parallel, msm_parallel, msm_precompute, AffinePoint, Curve, Field, HaloCurve, PolynomialCommitment, ProjectivePoint, Proof, SchnorrProof};
+use crate::{msm_execute_parallel, msm_parallel, msm_precompute, AffinePoint, Curve, Field, HaloCurve, PolynomialCommitment, ProjectivePoint, SchnorrProof};
 use anyhow::Result;
 use rayon::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ mod plonk_proof;
 mod plonk_recursion;
 pub mod plonk_util;
 pub mod poly_commit;
-mod polynomial;
+pub mod polynomial;
 mod pseudorandom;
 mod rescue;
 mod serialization;

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -10,13 +10,13 @@ use crate::halo::batch_opening_proof;
 use crate::partition::{get_subgroup_shift, TargetPartitions};
 use crate::plonk_challenger::Challenger;
 use crate::plonk_proof::{OldProof, Proof, SchnorrProof};
-use crate::plonk_util::{coeffs_to_values_padded, commit_polynomials, eval_l_1, eval_poly, eval_polys, eval_zero_poly, halo_n, halo_n_mul, pad_to_8n, permutation_polynomial, powers, reduce_with_powers, values_to_polynomials};
+use crate::plonk_util::{coeffs_to_values_padded, commit_polynomials, eval_l_1, eval_polys, eval_zero_poly, halo_n, halo_n_mul, pad_to_8n, permutation_polynomial, powers, reduce_with_powers, values_to_polynomials};
 use crate::poly_commit::PolynomialCommitment;
 use crate::polynomial::Polynomial;
 use crate::target::Target;
 use crate::util::{ceil_div_usize, log2_strict};
 use crate::witness::{PartialWitness, Witness, WitnessGenerator};
-use crate::{evaluate_all_constraints, fft_with_precomputation_power_of_2, ifft_with_precomputation_power_of_2, msm_parallel, AffinePoint, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, OpeningSet, ProjectivePoint, VerificationKey};
+use crate::{evaluate_all_constraints, fft_with_precomputation_power_of_2, msm_parallel, AffinePoint, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, OpeningSet, ProjectivePoint, VerificationKey};
 
 pub(crate) const NUM_WIRES: usize = 9;
 pub(crate) const NUM_ROUTED_WIRES: usize = 6;

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -10,7 +10,7 @@ use crate::halo::batch_opening_proof;
 use crate::partition::{get_subgroup_shift, TargetPartitions};
 use crate::plonk_challenger::Challenger;
 use crate::plonk_proof::{OldProof, Proof};
-use crate::plonk_util::{coeffs_to_values_padded, commit_polynomials, eval_l_1, eval_polys, eval_zero_poly, pad_to_8n, permutation_polynomial, powers, reduce_with_powers, values_to_polynomials};
+use crate::plonk_util::{commit_polynomials, eval_l_1, eval_polys, eval_zero_poly, pad_to_8n, permutation_polynomial, polynomials_to_values_padded, powers, reduce_with_powers, values_to_polynomials};
 use crate::poly_commit::PolynomialCommitment;
 use crate::polynomial::Polynomial;
 use crate::target::Target;
@@ -94,7 +94,7 @@ impl<C: HaloCurve> Circuit<C> {
         let wire_polynomials =
             values_to_polynomials(&wire_values_by_wire_index, &self.fft_precomputation_n);
         let wire_values_8n =
-            coeffs_to_values_padded(&wire_polynomials, &self.fft_precomputation_8n);
+            polynomials_to_values_padded(&wire_polynomials, &self.fft_precomputation_8n);
 
         // Commit to the wire polynomials.
         let c_wires = commit_polynomials(

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -10,13 +10,13 @@ use crate::halo::batch_opening_proof;
 use crate::partition::{get_subgroup_shift, TargetPartitions};
 use crate::plonk_challenger::Challenger;
 use crate::plonk_proof::{OldProof, Proof, SchnorrProof};
-use crate::plonk_util::{coeffs_to_values_padded, eval_coeffs, eval_l_1, eval_poly, eval_zero_poly, halo_n, halo_n_mul, pad_to_8n, permutation_polynomial, powers, reduce_with_powers, values_to_coeffs};
+use crate::plonk_util::{coeffs_to_values_padded, commit_polynomials, eval_l_1, eval_poly, eval_polys, eval_zero_poly, halo_n, halo_n_mul, pad_to_8n, permutation_polynomial, powers, reduce_with_powers, values_to_polynomials};
 use crate::poly_commit::PolynomialCommitment;
-use crate::polynomial::{polynomial_division, polynomial_multiplication, trim as trim_polynomial};
+use crate::polynomial::Polynomial;
 use crate::target::Target;
 use crate::util::{ceil_div_usize, log2_strict};
 use crate::witness::{PartialWitness, Witness, WitnessGenerator};
-use crate::{divide_by_z_h, evaluate_all_constraints, fft_with_precomputation_power_of_2, ifft_with_precomputation_power_of_2, msm_parallel, AffinePoint, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, OpeningSet, ProjectivePoint, VerificationKey};
+use crate::{evaluate_all_constraints, fft_with_precomputation_power_of_2, ifft_with_precomputation_power_of_2, msm_parallel, AffinePoint, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, OpeningSet, ProjectivePoint, VerificationKey};
 
 pub(crate) const NUM_WIRES: usize = 9;
 pub(crate) const NUM_ROUTED_WIRES: usize = 6;
@@ -49,13 +49,13 @@ pub struct Circuit<C: HaloCurve> {
     /// The generator U used in Halo.
     pub u: AffinePoint<C>,
     /// Each constant polynomial, in coefficient form.
-    pub constants_coeffs: Vec<Vec<C::ScalarField>>,
+    pub constant_polynomials: Vec<Polynomial<C::ScalarField>>,
     /// Each constant polynomial, in point-value form, low-degree extended to be degree 8n.
     pub constants_8n: Vec<Vec<C::ScalarField>>,
     /// A commitment to each constant polynomial.
     pub c_constants: Vec<PolynomialCommitment<C>>,
     /// Each permutation polynomial, in coefficient form.
-    pub s_sigma_coeffs: Vec<Vec<C::ScalarField>>,
+    pub s_sigma_polynomials: Vec<Polynomial<C::ScalarField>>,
     /// Each permutation polynomial, low-degree extended to be degree 8n.
     pub s_sigma_values_8n: Vec<Vec<C::ScalarField>>,
     /// A commitment to each permutation polynomial.
@@ -91,12 +91,14 @@ impl<C: HaloCurve> Circuit<C> {
 
         // Convert the witness both to coefficient form and a degree-8n LDE.
         let wire_values_by_wire_index = &witness.transpose();
-        let wires_coeffs = values_to_coeffs(&wire_values_by_wire_index, &self.fft_precomputation_n);
-        let wire_values_8n = coeffs_to_values_padded(&wires_coeffs, &self.fft_precomputation_8n);
+        let wire_polynomials =
+            values_to_polynomials(&wire_values_by_wire_index, &self.fft_precomputation_n);
+        let wire_values_8n =
+            coeffs_to_values_padded(&wire_polynomials, &self.fft_precomputation_8n);
 
         // Commit to the wire polynomials.
-        let c_wires = PolynomialCommitment::coeffs_vec_to_commitments(
-            &wires_coeffs,
+        let c_wires = commit_polynomials(
+            &wire_polynomials,
             &self.pedersen_g_msm_precomputation,
             self.pedersen_h,
             blinding_commitments,
@@ -105,7 +107,7 @@ impl<C: HaloCurve> Circuit<C> {
         let num_public_input_gates = ceil_div_usize(self.num_public_inputs, NUM_WIRES);
         // Compute the wire coefficients when the public input gates are set to zero.
         // Used only when `output_pis` is false, so they are set to `None` if `output_pis` is true.
-        let wires_coeffs_no_pis = if output_pis {
+        let wire_polynomials_no_pis = if output_pis {
             None
         } else {
             let mut wire_values_by_wire_no_pis = wire_values_by_wire_index.clone();
@@ -115,14 +117,14 @@ impl<C: HaloCurve> Circuit<C> {
                     w[2 * i] = C::ScalarField::ZERO;
                 }
             });
-            let wires_coeffs_no_pis =
-                values_to_coeffs(&wire_values_by_wire_no_pis, &self.fft_precomputation_n);
-            Some(wires_coeffs_no_pis)
+            Some(values_to_polynomials(
+                &wire_values_by_wire_no_pis,
+                &self.fft_precomputation_n,
+            ))
         };
 
         // Generate a random beta and gamma from the transcript.
-        challenger
-            .observe_affine_points(&c_wires.iter().map(|c| c.to_affine()).collect::<Vec<_>>());
+        challenger.observe_affine_points(&PolynomialCommitment::to_affine_vec(&c_wires));
         let (beta_bf, gamma_bf) = challenger.get_2_challenges();
         let beta_sf = beta_bf.try_convert::<C::ScalarField>()?;
         let gamma_sf = gamma_bf.try_convert::<C::ScalarField>()?;
@@ -136,10 +138,9 @@ impl<C: HaloCurve> Circuit<C> {
             gamma_sf,
         );
         // Commit to Z.
-        let plonk_z_coeffs =
-            ifft_with_precomputation_power_of_2(&plonk_z_points_n, &self.fft_precomputation_n);
-        let c_plonk_z = PolynomialCommitment::coeffs_to_commitment(
-            &plonk_z_coeffs,
+        let plonk_z_polynomial =
+            Polynomial::from_evaluations(&plonk_z_points_n, &self.fft_precomputation_n);
+        let c_plonk_z = plonk_z_polynomial.commit(
             &self.pedersen_g_msm_precomputation,
             self.pedersen_h,
             blinding_commitments,
@@ -151,19 +152,19 @@ impl<C: HaloCurve> Circuit<C> {
         let alpha_sf = alpha_bf.try_convert::<C::ScalarField>()?;
 
         // Generate the vanishing polynomial.
-        let vanishing_coeffs = self.vanishing_poly_coeffs::<InnerC>(
+        let vanishing_poly = self.vanishing_poly::<InnerC>(
             &wire_values_8n,
             alpha_sf,
             beta_sf,
             gamma_sf,
-            &plonk_z_coeffs,
+            &plonk_z_polynomial[..],
         );
 
         if cfg!(debug_assertions) {
             // Check that the vanishing polynomial indeed vanishes.
             self.subgroup_n.iter().enumerate().for_each(|(i, &x)| {
                 assert!(
-                    eval_poly(&vanishing_coeffs, x).is_zero(),
+                    vanishing_poly.eval(x).is_zero(),
                     "{}-th gate constraints are not satisfied",
                     i
                 );
@@ -171,82 +172,73 @@ impl<C: HaloCurve> Circuit<C> {
         }
 
         // Compute the quotient polynomial, t(x) = vanishing(x) / Z_H(x).
-        let mut plonk_t_coeffs: Vec<C::ScalarField> =
-            divide_by_z_h(&vanishing_coeffs, self.degree());
+        let mut plonk_t_poly = vanishing_poly.divide_by_z_h(self.degree());
 
         if cfg!(debug_assertions) {
             // Check that division was performed correctly by evaluating at a random point.
-            let xxx = C::ScalarField::rand();
+            let x = C::ScalarField::rand();
             assert_eq!(
-                eval_poly(&plonk_t_coeffs, xxx),
-                eval_poly(&vanishing_coeffs, xxx) / eval_zero_poly(self.degree(), xxx)
+                plonk_t_poly.eval(x),
+                vanishing_poly.eval(x) / eval_zero_poly(self.degree(), x),
             );
         }
 
         // Pad the coefficients to 7n.
-        if plonk_t_coeffs.len() != QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER * self.degree() {
-            plonk_t_coeffs.extend(
-                (plonk_t_coeffs.len()..QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER * self.degree())
-                    .map(|_| C::ScalarField::ZERO),
-            );
-        }
+        plonk_t_poly.pad(QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER * self.degree());
 
         // Split t into degree-n chunks.
-        let plonk_t_coeff_chunks: Vec<Vec<C::ScalarField>> = plonk_t_coeffs
+        let plonk_t_poly_chunks = plonk_t_poly
+            .coeffs()
             .chunks(self.degree())
-            .map(|chunk| chunk.to_vec())
-            .collect();
+            .map(|chunk| Polynomial::from(chunk.to_vec()))
+            .collect::<Vec<_>>();
 
         // Commit to the quotient polynomial.
-        let c_plonk_t = PolynomialCommitment::coeffs_vec_to_commitments(
-            &plonk_t_coeff_chunks,
+        let c_plonk_t = commit_polynomials(
+            &plonk_t_poly_chunks,
             &self.pedersen_g_msm_precomputation,
             self.pedersen_h,
             blinding_commitments,
         );
 
         // Combine the coefficients in `wires_coeffs_no_pis` using a linear combination weighted by `alpha`.
-        let vanishing_pis_coeffs = wires_coeffs_no_pis.map(|w| {
-            (0..self.degree())
-                .map(|i| {
-                    (0..w.len())
-                        .map(|j| w[j][i] * alpha_sf.exp_usize(j))
-                        .fold(C::ScalarField::ZERO, |acc, x| acc + x)
-                })
-                .collect::<Vec<_>>()
+        let vanishing_pis_poly = wire_polynomials_no_pis.map(|w| {
+            Polynomial::from(
+                (0..self.degree())
+                    .map(|i| {
+                        (0..w.len())
+                            .map(|j| w[j][i] * alpha_sf.exp_usize(j))
+                            .fold(C::ScalarField::ZERO, |acc, x| acc + x)
+                    })
+                    .collect::<Vec<_>>(),
+            )
         });
-        // `vanishing_pis_coeffs` vanishes at the public input gates. It is thus divisible by the vanishing
+        // `vanishing_pis_poly` vanishes at the public input gates. It is thus divisible by the vanishing
         // polynomial at the public input gates. The quotient is computed here.
-        let pis_quotient_coeffs = vanishing_pis_coeffs.map(|coeffs| {
+        let pis_quotient_coeffs = vanishing_pis_poly.map(|poly| {
             // The vanishing polynomial of a set `S` is `prod_{s \in S} (X-s)`.
             // TODO: Faster implementation.
-            let pis_quotient_denominator =
-                (0..num_public_input_gates).fold(vec![C::ScalarField::ONE], |acc, i| {
-                    let mut ans = polynomial_multiplication(
-                        &acc,
-                        &vec![-self.subgroup_n[2 * i], C::ScalarField::ONE],
-                    );
-                    trim_polynomial(&mut ans);
+            let pis_quotient_denominator = (0..num_public_input_gates).fold(
+                Polynomial::from(vec![C::ScalarField::ONE]),
+                |acc, i| {
+                    let mut ans =
+                        acc.mul(&vec![-self.subgroup_n[2 * i], C::ScalarField::ONE].into());
+                    ans.trim();
                     ans
-                });
-            let mut ans = polynomial_division(&coeffs, &pis_quotient_denominator).0;
+                },
+            );
+            let mut ans = poly.polynomial_division(&pis_quotient_denominator).0;
             if cfg!(debug_assertions) {
                 // Check that division was performed correctly by evaluating at a random point.
-                let xxx = C::ScalarField::rand();
-                assert_eq!(
-                    eval_poly(&ans, xxx),
-                    eval_poly(&coeffs, xxx) / eval_poly(&pis_quotient_denominator, xxx)
-                );
+                let x = C::ScalarField::rand();
+                assert_eq!(ans.eval(x), poly.eval(x) / pis_quotient_denominator.eval(x));
             }
-            for _ in ans.len()..self.degree() {
-                ans.push(C::ScalarField::ZERO);
-            }
+            ans.pad(self.degree());
             ans
         });
         // Commit to the public inputs quotient polynomial.
-        let c_pis_quotient = pis_quotient_coeffs.as_ref().map(|coeffs| {
-            PolynomialCommitment::coeffs_to_commitment(
-                coeffs,
+        let c_pis_quotient = pis_quotient_coeffs.as_ref().map(|poly| {
+            poly.commit(
                 &self.pedersen_g_msm_precomputation,
                 self.pedersen_h,
                 blinding_commitments,
@@ -258,8 +250,7 @@ impl<C: HaloCurve> Circuit<C> {
             .collect::<Vec<_>>();
 
         // Generate a random zeta from the transcript.
-        challenger
-            .observe_affine_points(&c_plonk_t.iter().map(|c| c.to_affine()).collect::<Vec<_>>());
+        challenger.observe_affine_points(&PolynomialCommitment::to_affine_vec(&c_plonk_t));
         if let Some(comm) = c_pis_quotient {
             challenger.observe_affine_point(comm.to_affine());
             // Observe the public inputs
@@ -280,9 +271,9 @@ impl<C: HaloCurve> Circuit<C> {
                     .map(|i| i * 2)
                     .map(|i| {
                         self.open_all_polynomials(
-                            &wires_coeffs,
-                            &plonk_z_coeffs,
-                            &plonk_t_coeff_chunks,
+                            &wire_polynomials,
+                            &plonk_z_polynomial,
+                            &plonk_t_poly_chunks,
                             old_proofs,
                             &pis_quotient_coeffs,
                             self.subgroup_generator_n.exp_usize(i),
@@ -296,25 +287,25 @@ impl<C: HaloCurve> Circuit<C> {
 
         // Open all polynomials at zeta, zeta * g, and zeta * g^65.
         let o_local = self.open_all_polynomials(
-            &wires_coeffs,
-            &plonk_z_coeffs,
-            &plonk_t_coeff_chunks,
+            &wire_polynomials,
+            &plonk_z_polynomial,
+            &plonk_t_poly_chunks,
             old_proofs,
             &pis_quotient_coeffs,
             zeta_sf,
         );
         let o_right = self.open_all_polynomials(
-            &wires_coeffs,
-            &plonk_z_coeffs,
-            &plonk_t_coeff_chunks,
+            &wire_polynomials,
+            &plonk_z_polynomial,
+            &plonk_t_poly_chunks,
             old_proofs,
             &pis_quotient_coeffs,
             zeta_sf * self.subgroup_generator_n,
         );
         let o_below = self.open_all_polynomials(
-            &wires_coeffs,
-            &plonk_z_coeffs,
-            &plonk_t_coeff_chunks,
+            &wire_polynomials,
+            &plonk_z_polynomial,
+            &plonk_t_poly_chunks,
             old_proofs,
             &pis_quotient_coeffs,
             zeta_sf * self.subgroup_generator_n.exp_usize(GRID_WIDTH),
@@ -351,14 +342,17 @@ impl<C: HaloCurve> Circuit<C> {
         let u_sf = u_bf.try_convert::<C::ScalarField>()?;
         let u_scaling_sf = u_scaling_bf.try_convert::<C::ScalarField>()?;
 
-        let old_proofs_coeffs = old_proofs.iter().map(|p| p.coeffs()).collect::<Vec<_>>();
+        let old_proofs_polys = old_proofs
+            .iter()
+            .map(|p| Polynomial::from(p.coeffs()))
+            .collect::<Vec<_>>();
         let all_coeffs = [
-            self.constants_coeffs.clone(),
-            self.s_sigma_coeffs.clone(),
-            wires_coeffs,
-            vec![plonk_z_coeffs],
-            plonk_t_coeff_chunks,
-            old_proofs_coeffs,
+            self.constant_polynomials.clone(),
+            self.s_sigma_polynomials.clone(),
+            wire_polynomials,
+            vec![plonk_z_polynomial],
+            plonk_t_poly_chunks,
+            old_proofs_polys,
             pis_quotient_coeffs.map(|c| vec![c]).unwrap_or_default(),
         ]
         .concat();
@@ -425,14 +419,14 @@ impl<C: HaloCurve> Circuit<C> {
         })
     }
 
-    fn vanishing_poly_coeffs<InnerC: HaloCurve<BaseField = C::ScalarField>>(
+    fn vanishing_poly<InnerC: HaloCurve<BaseField = C::ScalarField>>(
         &self,
         wire_values_8n: &[Vec<C::ScalarField>],
         alpha_sf: C::ScalarField,
         beta_sf: C::ScalarField,
         gamma_sf: C::ScalarField,
         plonk_z_coeffs: &[C::ScalarField],
-    ) -> Vec<C::ScalarField> {
+    ) -> Polynomial<C::ScalarField> {
         let degree = self.degree();
         let k_is = (0..NUM_ROUTED_WIRES)
             .map(get_subgroup_shift::<C::ScalarField>)
@@ -505,30 +499,30 @@ impl<C: HaloCurve> Circuit<C> {
             })
             .collect::<Vec<_>>();
 
-        ifft_with_precomputation_power_of_2(&vanishing_points, &self.fft_precomputation_8n)
+        Polynomial::from_evaluations(&vanishing_points, &self.fft_precomputation_8n)
     }
 
     /// Open each polynomial at the given point, `zeta`.
     fn open_all_polynomials(
         &self,
-        wire_coeffs: &[Vec<C::ScalarField>],
-        plonk_z_coeffs: &[C::ScalarField],
-        plonk_t_coeffs: &[Vec<C::ScalarField>],
+        wire_poly: &[Polynomial<C::ScalarField>],
+        plonk_z_poly: &Polynomial<C::ScalarField>,
+        plonk_t_polys: &[Polynomial<C::ScalarField>],
         old_proofs: &[OldProof<C>],
-        pi_quotient_coeffs: &Option<Vec<C::ScalarField>>,
+        pi_quotient_poly: &Option<Polynomial<C::ScalarField>>,
         zeta: C::ScalarField,
     ) -> OpeningSet<C::ScalarField> {
         let powers_of_zeta = powers(zeta, self.degree());
 
         OpeningSet {
-            o_constants: eval_coeffs(&self.constants_coeffs, &powers_of_zeta),
-            o_plonk_sigmas: eval_coeffs(&self.s_sigma_coeffs, &powers_of_zeta),
-            o_wires: eval_coeffs(&wire_coeffs, &powers_of_zeta),
-            o_plonk_z: C::ScalarField::inner_product(&plonk_z_coeffs, &powers_of_zeta),
-            o_plonk_t: eval_coeffs(&plonk_t_coeffs, &powers_of_zeta),
-            o_pi_quotient: pi_quotient_coeffs
+            o_constants: eval_polys(&self.constant_polynomials, &powers_of_zeta),
+            o_plonk_sigmas: eval_polys(&self.s_sigma_polynomials, &powers_of_zeta),
+            o_wires: eval_polys(&wire_poly, &powers_of_zeta),
+            o_plonk_z: plonk_z_poly.eval_from_power(&powers_of_zeta),
+            o_plonk_t: eval_polys(&plonk_t_polys, &powers_of_zeta),
+            o_pi_quotient: pi_quotient_poly
                 .as_ref()
-                .map(|coeffs| C::ScalarField::inner_product(&coeffs, &powers_of_zeta)),
+                .map(|poly| poly.eval_from_power(&powers_of_zeta)),
             o_old_proofs: old_proofs
                 .iter()
                 .map(|p| p.evaluate_g(zeta))

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -9,14 +9,14 @@ use rayon::prelude::*;
 use crate::halo::batch_opening_proof;
 use crate::partition::{get_subgroup_shift, TargetPartitions};
 use crate::plonk_challenger::Challenger;
-use crate::plonk_proof::{OldProof, Proof, SchnorrProof};
-use crate::plonk_util::{coeffs_to_values_padded, commit_polynomials, eval_l_1, eval_polys, eval_zero_poly, halo_n, halo_n_mul, pad_to_8n, permutation_polynomial, powers, reduce_with_powers, values_to_polynomials};
+use crate::plonk_proof::{OldProof, Proof};
+use crate::plonk_util::{coeffs_to_values_padded, commit_polynomials, eval_l_1, eval_polys, eval_zero_poly, pad_to_8n, permutation_polynomial, powers, reduce_with_powers, values_to_polynomials};
 use crate::poly_commit::PolynomialCommitment;
 use crate::polynomial::Polynomial;
 use crate::target::Target;
 use crate::util::{ceil_div_usize, log2_strict};
 use crate::witness::{PartialWitness, Witness, WitnessGenerator};
-use crate::{evaluate_all_constraints, fft_with_precomputation_power_of_2, msm_parallel, AffinePoint, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, OpeningSet, ProjectivePoint, VerificationKey};
+use crate::{evaluate_all_constraints, fft_with_precomputation_power_of_2, AffinePoint, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, OpeningSet, VerificationKey};
 
 pub(crate) const NUM_WIRES: usize = 9;
 pub(crate) const NUM_ROUTED_WIRES: usize = 6;

--- a/src/plonk_challenger.rs
+++ b/src/plonk_challenger.rs
@@ -80,7 +80,7 @@ impl<F: Field> Challenger<F> {
         (self.get_challenge(), self.get_challenge())
     }
 
-    pub(crate) fn get_3_challenges(&mut self) -> (F, F, F) {
+    pub fn get_3_challenges(&mut self) -> (F, F, F) {
         (
             self.get_challenge(),
             self.get_challenge(),
@@ -88,8 +88,7 @@ impl<F: Field> Challenger<F> {
         )
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn get_n_challenges(&mut self, n: usize) -> Vec<F> {
+    pub fn get_n_challenges(&mut self, n: usize) -> Vec<F> {
         (0..n).map(|_| self.get_challenge()).collect()
     }
 

--- a/src/plonk_challenger.rs
+++ b/src/plonk_challenger.rs
@@ -80,7 +80,7 @@ impl<F: Field> Challenger<F> {
         (self.get_challenge(), self.get_challenge())
     }
 
-    pub fn get_3_challenges(&mut self) -> (F, F, F) {
+    pub(crate) fn get_3_challenges(&mut self) -> (F, F, F) {
         (
             self.get_challenge(),
             self.get_challenge(),
@@ -88,7 +88,8 @@ impl<F: Field> Challenger<F> {
         )
     }
 
-    pub fn get_n_challenges(&mut self, n: usize) -> Vec<F> {
+    #[allow(dead_code)]
+    pub(crate) fn get_n_challenges(&mut self, n: usize) -> Vec<F> {
         (0..n).map(|_| self.get_challenge()).collect()
     }
 
@@ -182,6 +183,7 @@ impl<C: HaloCurve> RecursiveChallenger<C> {
         )
     }
 
+    #[allow(dead_code)]
     pub(crate) fn get_n_challenges(
         &mut self,
         builder: &mut CircuitBuilder<C>,

--- a/src/plonk_proof.rs
+++ b/src/plonk_proof.rs
@@ -226,6 +226,7 @@ pub struct ProofTarget {
 
 impl ProofTarget {
     /// `log_2(d)`, where `d` is the degree of the proof being verified.
+    #[allow(dead_code)]
     fn degree_pow(&self) -> usize {
         self.halo_l_i.len()
     }

--- a/src/plonk_util.rs
+++ b/src/plonk_util.rs
@@ -178,26 +178,14 @@ pub(crate) fn values_to_polynomials<F: Field>(
         .collect()
 }
 
-#[allow(dead_code)]
-pub(crate) fn coeffs_to_values<F: Field>(
-    polys_vec: &[Polynomial<F>],
-    fft_precomputation: &FftPrecomputation<F>,
-) -> Vec<Vec<F>> {
-    polys_vec
-        .par_iter()
-        .map(|poly| poly.eval_domain(fft_precomputation))
-        .collect()
-}
-
-pub(crate) fn coeffs_to_values_padded<F: Field>(
+pub(crate) fn polynomials_to_values_padded<F: Field>(
     polys_vec: &[Polynomial<F>],
     fft_precomputation: &FftPrecomputation<F>,
 ) -> Vec<Vec<F>> {
     polys_vec
         .par_iter()
         .map(|poly| {
-            let mut padded_poly = poly.clone();
-            padded_poly.pad(poly.len() * 8);
+            let padded_poly = poly.padded(poly.len() * 8);
             padded_poly.eval_domain(fft_precomputation)
         })
         .collect()

--- a/src/plonk_util.rs
+++ b/src/plonk_util.rs
@@ -1,6 +1,6 @@
 use crate::partition::get_subgroup_shift;
 use crate::witness::Witness;
-use crate::{fft_with_precomputation_power_of_2, ifft_with_precomputation_power_of_2, msm_execute_parallel, AffinePoint, CircuitBuilder, Curve, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, Polynomial, PolynomialCommitment, ProjectivePoint, Target, NUM_ROUTED_WIRES};
+use crate::{ifft_with_precomputation_power_of_2, msm_execute_parallel, AffinePoint, CircuitBuilder, Curve, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, Polynomial, PolynomialCommitment, ProjectivePoint, Target, NUM_ROUTED_WIRES};
 use rayon::prelude::*;
 
 /// Evaluate the polynomial which vanishes on any multiplicative subgroup of a given order `n`.
@@ -178,6 +178,7 @@ pub(crate) fn values_to_polynomials<F: Field>(
         .collect()
 }
 
+#[allow(dead_code)]
 pub(crate) fn coeffs_to_values<F: Field>(
     polys_vec: &[Polynomial<F>],
     fft_precomputation: &FftPrecomputation<F>,
@@ -210,6 +211,7 @@ pub fn pedersen_hash<C: Curve>(
     msm_execute_parallel(pedersen_g_msm_precomputation, xs)
 }
 
+#[allow(dead_code)]
 fn pedersen_commit<C: Curve>(
     xs: &[C::ScalarField],
     opening: C::ScalarField,
@@ -291,6 +293,7 @@ pub fn sigma_polynomials<F: Field>(
         .collect()
 }
 
+#[allow(dead_code)]
 pub(crate) fn polynomial_degree_plus_1<F: Field>(
     points: &[F],
     fft_precomputation: &FftPrecomputation<F>,

--- a/src/poly_commit.rs
+++ b/src/poly_commit.rs
@@ -50,7 +50,7 @@ impl<C: Curve> PolynomialCommitment<C> {
 
     /// Creates a list of polynomial commitments from a list of polynomials in coefficients vector form.
     pub fn coeffs_vec_to_commitments(
-        coefficients_vec: &[Vec<C::ScalarField>],
+        coefficients_vec: &[&[C::ScalarField]],
         msm_precomputation: &MsmPrecomputation<C>,
         blinding_point: AffinePoint<C>,
         blinding: bool,

--- a/src/poly_commit.rs
+++ b/src/poly_commit.rs
@@ -98,4 +98,10 @@ impl<C: Curve> PolynomialCommitment<C> {
             CurvePoint::Projective(p) => p.to_affine(),
         }
     }
+
+    /// Returns the commitment point in affine coordinates.
+    /// `Self::batch_to_affine` should be run first for better performances.
+    pub fn to_affine_vec(comms: &[Self]) -> Vec<AffinePoint<C>> {
+        comms.iter().map(|c| c.to_affine()).collect()
+    }
 }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use std::ops::{Index, IndexMut, RangeBounds};
 use std::slice::{Iter, IterMut, SliceIndex};
 
-/// Polynomial struc holding a polynomial in coefficient form.
+/// Polynomial struct holding a polynomial in coefficient form.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Polynomial<F: Field>(Vec<F>);
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -338,16 +338,6 @@ mod test {
     use rand::{thread_rng, Rng};
     use std::time::Instant;
 
-    fn evaluate_at_naive<F: Field>(coefficients: &[F], point: F) -> F {
-        let mut sum = F::ZERO;
-        let mut point_power = F::ONE;
-        for &c in coefficients {
-            sum = sum + c * point_power;
-            point_power = point_power * point;
-        }
-        sum
-    }
-
     #[test]
     fn test_polynomial_multiplication() {
         type F = TweedledeeBase;

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -1,213 +1,301 @@
-use crate::{fft_precompute, fft_with_precomputation, ifft_with_precomputation_power_of_2, util::log2_ceil, Field};
+use crate::{fft_precompute, fft_with_precomputation, ifft_with_precomputation_power_of_2, util::log2_ceil, FftPrecomputation, Field};
+use std::ops::{Index, IndexMut, RangeBounds};
+use std::slice::{Iter, IterMut, SliceIndex};
 
-// Store polynomial as a list of coefficient starting with the constant coefficient.
-type Polynomial<F> = Vec<F>;
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Polynomial<F: Field>(Vec<F>);
 
-fn degree<F: Field>(a: &Polynomial<F>) -> usize {
-    let mut ans = 0;
-    a.iter().enumerate().for_each(|(i, x)| {
-        if x.is_nonzero() {
-            ans = i;
-        }
-    });
-    ans
-}
-
-fn lead<F: Field>(a: &Polynomial<F>) -> F {
-    let mut ans = F::ZERO;
-    a.iter().for_each(|&x| {
-        if x.is_nonzero() {
-            ans = x;
-        }
-    });
-    ans
-}
-
-pub fn polynomial_is_zero<F: Field>(a: &Polynomial<F>) -> bool {
-    a.iter().all(|&x| x.is_zero())
-}
-
-fn rev<F: Field>(a: &Polynomial<F>) -> Polynomial<F> {
-    assert!(a.last().unwrap().is_nonzero());
-    let mut r = a.to_vec();
-    r.reverse();
-    r
-}
-
-fn neg<F: Field>(a: &Polynomial<F>) -> Polynomial<F> {
-    a.iter().map(|&x| -x).collect()
-}
-
-pub fn trim<F: Field>(a: &mut Polynomial<F>) {
-    let d = degree(a);
-    a.drain(d + 1..);
-}
-
-pub fn polynomial_addition<F: Field>(a: &Polynomial<F>, b: &Polynomial<F>) -> Polynomial<F> {
-    a.iter().zip(b.iter()).map(|(&ca, &cb)| ca + cb).collect()
-}
-
-pub fn polynomial_multiplication<F: Field>(a: &Polynomial<F>, b: &Polynomial<F>) -> Polynomial<F> {
-    let a_deg = a.len();
-    let b_deg = b.len();
-    let mut a_pad = a.clone();
-    a_pad.append(&mut vec![F::ZERO; b_deg]);
-    let mut b_pad = b.clone();
-    b_pad.append(&mut vec![F::ZERO; a_deg]);
-    let precomputation = fft_precompute(a_deg + b_deg);
-    let a_evals = fft_with_precomputation(&a_pad, &precomputation);
-    let b_evals = fft_with_precomputation(&b_pad, &precomputation);
-
-    let mul_evals: Vec<F> = a_evals
-        .iter()
-        .zip(b_evals.iter())
-        .map(|(&pa, &pb)| pa * pb)
-        .collect();
-    ifft_with_precomputation_power_of_2(&mul_evals, &precomputation)
-}
-
-pub fn polynomial_long_division<F: Field>(
-    a: &Polynomial<F>,
-    b: &Polynomial<F>,
-) -> (Polynomial<F>, Polynomial<F>) {
-    let (a_degree, b_degree) = (degree(a), degree(b));
-    if polynomial_is_zero(a) {
-        (Vec::new(), Vec::new())
-    } else if polynomial_is_zero(b) {
-        panic!("Division by zero polynomial");
-    } else if a_degree < b_degree {
-        (Vec::new(), a.to_vec())
-    } else {
-        // Now we know that self.degree() >= divisor.degree();
-        let mut quotient = vec![F::ZERO; a_degree - b_degree + 1];
-        let mut remainder = a.to_vec();
-        // Can unwrap here because we know self is not zero.
-        let divisor_leading_inv = lead(b).multiplicative_inverse_assuming_nonzero();
-        while !polynomial_is_zero(&remainder) && degree(&remainder) >= b_degree {
-            let cur_q_coeff = *remainder.last().unwrap() * divisor_leading_inv;
-            let cur_q_degree = remainder.len() - 1 - b_degree;
-            quotient[cur_q_degree] = cur_q_coeff;
-
-            for (i, &div_coeff) in b.iter().enumerate() {
-                remainder[cur_q_degree + i] =
-                    remainder[cur_q_degree + i] - (cur_q_coeff * div_coeff);
-            }
-            while let Some(true) = remainder.last().map(|c| c.is_zero()) {
-                remainder.pop();
-            }
-        }
-        (quotient, remainder)
+impl<F: Field> From<Vec<F>> for Polynomial<F> {
+    fn from(coeffs: Vec<F>) -> Self {
+        Self(coeffs)
     }
 }
 
-fn inv_mod_xn<F: Field>(h: &Polynomial<F>, n: usize) -> Polynomial<F> {
-    assert!(h[0].is_nonzero(), "Inverse doesn't exist.");
-    let mut hh = h.clone();
-    if h.len() < n {
-        for _ in 0..n - h.len() {
-            hh.push(F::ZERO);
+impl<F, I> Index<I> for Polynomial<F>
+where
+    F: Field,
+    I: SliceIndex<[F]>,
+{
+    type Output = I::Output;
+
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<F, I> IndexMut<I> for Polynomial<F>
+where
+    F: Field,
+    I: SliceIndex<[F]>,
+{
+    fn index_mut(&mut self, index: I) -> &mut <Self as Index<I>>::Output {
+        &mut self.0[index]
+    }
+}
+
+impl<F: Field> Polynomial<F> {
+    fn from_coeffs(coeffs: &[F]) -> Self {
+        Self(coeffs.to_vec())
+    }
+
+    fn coeffs(&self) -> Vec<F> {
+        self.0.clone()
+    }
+
+    fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    fn zero(len: usize) -> Self {
+        Self(vec![F::ZERO; len])
+    }
+
+    fn iter(&self) -> Iter<F> {
+        self.0.iter()
+    }
+
+    fn iter_mut(&mut self) -> IterMut<F> {
+        self.0.iter_mut()
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0.iter().all(|x| x.is_zero())
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn drain<R: RangeBounds<usize>>(&mut self, range: R) {
+        self.0.drain(range);
+    }
+
+    fn eval(&self, x: F) -> F {
+        self.iter().rev().fold(F::ZERO, |acc, &c| acc * x + c)
+    }
+
+    fn eval_domain(&self, fft_precomputation: &FftPrecomputation<F>) -> Vec<F> {
+        fft_with_precomputation(&self.coeffs(), fft_precomputation)
+    }
+
+    fn from_evaluations(values: &[F], fft_precomputation: &FftPrecomputation<F>) -> Self {
+        Self(ifft_with_precomputation_power_of_2(
+            values,
+            fft_precomputation,
+        ))
+    }
+
+    fn degree(&self) -> usize {
+        (0usize..self.0.len())
+            .rev()
+            .find(|&i| self.0[i].is_nonzero())
+            .expect("Zero polynomial")
+    }
+
+    fn lead(&self) -> F {
+        self.iter()
+            .rev()
+            .find(|x| x.is_nonzero())
+            .map_or(F::ZERO, |x| *x)
+    }
+
+    fn rev(&self) -> Self {
+        let d = self.degree();
+        Self(self.0[..=d].iter().rev().copied().collect())
+    }
+
+    fn neg(&self) -> Self {
+        Self(self.iter().map(|&x| -x).collect())
+    }
+
+    fn trim(&mut self) {
+        if !self.is_zero() {
+            self.0.drain(self.degree() + 1..);
         }
     }
-    let mut a: Polynomial<F> = Vec::new();
-    a.push(hh[0].multiplicative_inverse_assuming_nonzero());
-    for i in 0..log2_ceil(n) {
-        let l = 1 << i;
-        let h0 = hh[..l].to_vec();
-        let mut h1 = hh[l..].to_vec();
-        let mut c = polynomial_multiplication(&a, &h0);
-        if l == c.len() {
-            c = vec![F::ZERO];
+
+    fn add(&self, other: &Self) -> Self {
+        let (mut a, mut b) = (self.clone(), other.clone());
+        if a.len() < b.len() {
+            a.pad(b.len())
+        } else if b.len() < a.len() {
+            b.pad(a.len());
+        }
+        Self(a.iter().zip(b.iter()).map(|(&x, &y)| x + y).collect())
+    }
+
+    fn pad(&mut self, len: usize) {
+        assert!(self.len() <= len);
+        self.0.extend((self.len()..len).map(|_| F::ZERO));
+    }
+
+    fn mul(&self, b: &Self) -> Self {
+        if self.is_zero() || b.is_zero() {
+            return Self::zero(1);
+        }
+        let a_deg = self.degree();
+        let b_deg = b.degree();
+        let mut a_pad = self.clone();
+        a_pad.pad(a_deg + b_deg + 1);
+        let mut b_pad = b.clone();
+        b_pad.pad(a_deg + b_deg + 1);
+
+        let precomputation = fft_precompute(a_deg + b_deg + 1);
+        let a_evals = fft_with_precomputation(&a_pad.0, &precomputation);
+        let b_evals = fft_with_precomputation(&b_pad.0, &precomputation);
+
+        let mul_evals: Vec<F> = a_evals
+            .iter()
+            .zip(b_evals.iter())
+            .map(|(&pa, &pb)| pa * pb)
+            .collect();
+        ifft_with_precomputation_power_of_2(&mul_evals, &precomputation).into()
+    }
+
+    pub fn polynomial_long_division(&self, b: &Self) -> (Self, Self) {
+        let (a_degree, b_degree) = (self.degree(), b.degree());
+        if self.is_zero() {
+            (Self::zero(1), Self::empty())
+        } else if b.is_zero() {
+            panic!("Division by zero polynomial");
+        } else if a_degree < b_degree {
+            (Self::zero(1), self.clone())
         } else {
-            c.drain(0..l);
-        }
-        trim(&mut h1);
-        let mut tmp = polynomial_multiplication(&h1, &a);
-        tmp = polynomial_addition(&tmp, &c);
-        tmp.iter_mut().for_each(|x| *x = -(*x));
-        trim(&mut tmp);
-        let mut b = polynomial_multiplication(&a, &tmp)[..l].to_vec();
-        a.append(&mut b);
-    }
-    a.drain(n..);
-    a
-}
+            // Now we know that self.degree() >= divisor.degree();
+            let mut quotient = Self::zero(a_degree - b_degree + 1);
+            let mut remainder = self.clone();
+            // Can unwrap here because we know self is not zero.
+            let divisor_leading_inv = b.lead().multiplicative_inverse_assuming_nonzero();
+            while !remainder.is_zero() && remainder.degree() >= b_degree {
+                let cur_q_coeff = remainder.lead() * divisor_leading_inv;
+                let cur_q_degree = remainder.degree() - b_degree;
+                quotient[cur_q_degree] = cur_q_coeff;
 
-/// Returns `(q,r)` the quotient and remainder of the polynomial division of `a` by `b`.
-/// Algorithm from http://people.csail.mit.edu/madhu/ST12/scribe/lect06.pdf
-pub fn polynomial_division<F: Field>(
-    a: &Polynomial<F>,
-    b: &Polynomial<F>,
-) -> (Polynomial<F>, Polynomial<F>) {
-    let deg_a = degree(a);
-    let deg_b = degree(b);
-    let rev_b = rev(b);
-    let rev_b_inv = inv_mod_xn(&rev_b, deg_a - deg_b + 1);
-    let rev_q = polynomial_multiplication(&rev_b_inv, &rev(a)[..=deg_a - deg_b].to_vec())
-        [..=deg_a - deg_b]
-        .to_vec();
-    let mut q = rev(&rev_q);
-    let qb = polynomial_multiplication(&q, &b);
-    let mut r = polynomial_addition(&a, &neg(&qb));
-    trim(&mut q);
-    trim(&mut r);
-    (q, r)
-}
-
-// Divides a polynomial `a` by `Z_H = X^n - 1`. Assumes `Z_H | a`, otherwise result is meaningless.
-pub fn divide_by_z_h<F: Field>(a: &Polynomial<F>, n: usize) -> Polynomial<F> {
-    let mut a_trim = a.clone();
-    trim(&mut a_trim);
-    let g = F::MULTIPLICATIVE_SUBGROUP_GENERATOR;
-    let mut g_pow = F::ONE;
-    // Multiply the i-th coefficient of `a` by `g^i`. Then `new_a(w^j) = old_a(g.w^j)`.
-    a_trim.iter_mut().for_each(|x| {
-        *x = (*x) * g_pow;
-        g_pow = g * g_pow;
-    });
-    let d = degree(&a_trim);
-    let root = F::primitive_root_of_unity(log2_ceil(a_trim.len()));
-    let precomputation = fft_precompute(d + 1);
-    // Equals to the evaluation of `a` on `{g.w^i}`.
-    let mut a_eval = fft_with_precomputation(&a_trim, &precomputation);
-    // Compute the denominators `1/(g^n.w^(n*i) - 1)` using batch inversion.
-    let denominator_g = g.exp_usize(n);
-    let root_n = root.exp_usize(n);
-    let mut root_pow = F::ONE;
-    let denominators = (0..a_eval.len())
-        .map(|i| {
-            if i != 0 {
-                root_pow = root_pow * root_n;
+                for (i, &div_coeff) in b.iter().enumerate() {
+                    remainder[cur_q_degree + i] =
+                        remainder[cur_q_degree + i] - (cur_q_coeff * div_coeff);
+                }
+                remainder.trim();
             }
-            denominator_g * root_pow - F::ONE
-        })
-        .collect::<Vec<_>>();
-    let denominators_inv = F::batch_multiplicative_inverse(&denominators);
-    // Divide every element of `a_eval` by the corresponding denominator.
-    // Then, `a_eval` is the evaluation of `a/Z_H` on `{g.w^i}`.
-    a_eval
-        .iter_mut()
-        .zip(denominators_inv.iter())
-        .for_each(|(x, &d)| {
-            *x = (*x) * d;
-            root_pow = root_pow * root_n;
+            (quotient, remainder)
+        }
+    }
+
+    /// Computes the inverse of `self` modulo `x^n`.
+    fn inv_mod_xn(&self, n: usize) -> Self {
+        assert!(self[0].is_nonzero(), "Inverse doesn't exist.");
+        let mut h = self.clone();
+        if h.len() < n {
+            h.pad(n);
+        }
+        let mut a = Self::empty();
+        a.0.push(h[0].multiplicative_inverse_assuming_nonzero());
+        for i in 0..log2_ceil(n) {
+            let l = 1 << i;
+            let h0 = h[..l].to_vec().into();
+            let mut h1: Polynomial<F> = h[l..].to_vec().into();
+            let mut c = a.mul(&h0);
+            if l == c.len() {
+                c = Self::zero(1);
+            } else {
+                c.drain(0..l);
+            }
+            h1.trim();
+            let mut tmp = a.mul(&h1);
+            tmp = tmp.add(&c);
+            tmp.iter_mut().for_each(|x| *x = -(*x));
+            tmp.trim();
+            let b = &a.mul(&tmp)[..l];
+            a.0.extend_from_slice(b);
+        }
+        a.drain(n..);
+        a
+    }
+
+    /// Returns `(q,r)` the quotient and remainder of the polynomial division of `a` by `b`.
+    /// Algorithm from http://people.csail.mit.edu/madhu/ST12/scribe/lect06.pdf
+    pub fn polynomial_division(&self, b: &Self) -> (Self, Self) {
+        let (a_degree, b_degree) = (self.degree(), b.degree());
+        if self.is_zero() {
+            (Self::zero(1), Self::empty())
+        } else if b.is_zero() {
+            panic!("Division by zero polynomial");
+        } else if a_degree < b_degree {
+            (Self::zero(1), self.clone())
+        } else {
+            let rev_b = b.rev();
+            let rev_b_inv = rev_b.inv_mod_xn(a_degree - b_degree + 1);
+            let rev_q: Polynomial<F> = rev_b_inv
+                .mul(&self.rev()[..=a_degree - b_degree].to_vec().into())[..=a_degree - b_degree]
+                .to_vec()
+                .into();
+            let mut q = rev_q.rev();
+            let mut qb = q.mul(b);
+            qb.trim();
+            qb.pad(self.len());
+            let mut r = self.add(&qb.neg());
+            q.trim();
+            r.trim();
+            (q, r)
+        }
+    }
+
+    // Divides a polynomial `a` by `Z_H = X^n - 1`. Assumes `Z_H | a`, otherwise result is meaningless.
+    pub fn divide_by_z_h(&self, n: usize) -> Self {
+        let mut a_trim = self.clone();
+        a_trim.trim();
+        let g = F::MULTIPLICATIVE_SUBGROUP_GENERATOR;
+        let mut g_pow = F::ONE;
+        // Multiply the i-th coefficient of `a` by `g^i`. Then `new_a(w^j) = old_a(g.w^j)`.
+        a_trim.iter_mut().for_each(|x| {
+            *x = (*x) * g_pow;
+            g_pow = g * g_pow;
         });
-    // `p` is the interpolating polynomial of `a_eval` on `{w^i}`.
-    let mut p = ifft_with_precomputation_power_of_2(&a_eval, &precomputation);
-    // We need to scale it by `g^(-i)` to get the interpolating polynomial of `a_eval` on `{g.w^i}`,
-    // a.k.a `a/Z_H`.
-    let g_inv = g.multiplicative_inverse_assuming_nonzero();
-    let mut g_inv_pow = F::ONE;
-    p.iter_mut().for_each(|x| {
-        *x = (*x) * g_inv_pow;
-        g_inv_pow = g_inv_pow * g_inv;
-    });
-    p
+        let d = a_trim.degree();
+        let root = F::primitive_root_of_unity(log2_ceil(d + 1));
+        let precomputation = fft_precompute(d + 1);
+        // Equals to the evaluation of `a` on `{g.w^i}`.
+        let mut a_eval = a_trim.eval_domain(&precomputation);
+        // Compute the denominators `1/(g^n.w^(n*i) - 1)` using batch inversion.
+        let denominator_g = g.exp_usize(n);
+        let root_n = root.exp_usize(n);
+        let mut root_pow = F::ONE;
+        let denominators = (0..a_eval.len())
+            .map(|i| {
+                if i != 0 {
+                    root_pow = root_pow * root_n;
+                }
+                denominator_g * root_pow - F::ONE
+            })
+            .collect::<Vec<_>>();
+        let denominators_inv = F::batch_multiplicative_inverse(&denominators);
+        // Divide every element of `a_eval` by the corresponding denominator.
+        // Then, `a_eval` is the evaluation of `a/Z_H` on `{g.w^i}`.
+        a_eval
+            .iter_mut()
+            .zip(denominators_inv.iter())
+            .for_each(|(x, &d)| {
+                *x = (*x) * d;
+            });
+        // `p` is the interpolating polynomial of `a_eval` on `{w^i}`.
+        let mut p = Self::from_evaluations(&a_eval, &precomputation);
+        // We need to scale it by `g^(-i)` to get the interpolating polynomial of `a_eval` on `{g.w^i}`,
+        // a.k.a `a/Z_H`.
+        let g_inv = g.multiplicative_inverse_assuming_nonzero();
+        let mut g_inv_pow = F::ONE;
+        p.iter_mut().for_each(|x| {
+            *x = (*x) * g_inv_pow;
+            g_inv_pow = g_inv_pow * g_inv;
+        });
+        p
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::{Field, TweedledeeBase};
+    use rand::{thread_rng, Rng};
     use std::time::Instant;
 
     fn evaluate_at_naive<F: Field>(coefficients: &[F], point: F) -> F {
@@ -223,100 +311,81 @@ mod test {
     #[test]
     fn test_polynomial_multiplication() {
         type F = TweedledeeBase;
-        let a: Vec<F> = (0..128000).map(|_| F::rand()).collect();
-        let b: Vec<F> = (0..16000).map(|_| F::rand()).collect();
-        let m = polynomial_multiplication(&a, &b);
+        let mut rng = thread_rng();
+        let (a_deg, b_deg) = (rng.gen_range(1, 10_000), rng.gen_range(1, 10_000));
+        let a = Polynomial((0..a_deg).map(|_| F::rand()).collect());
+        let b = Polynomial((0..b_deg).map(|_| F::rand()).collect());
+        let m1 = a.mul(&b);
+        let m2 = a.mul(&b);
         for _ in 0..1000 {
             let x = F::rand();
-            assert_eq!(
-                evaluate_at_naive(&m, x),
-                evaluate_at_naive(&a, x) * evaluate_at_naive(&b, x)
-            );
+            assert_eq!(m1.eval(x), a.eval(x) * b.eval(x));
+            assert_eq!(m2.eval(x), a.eval(x) * b.eval(x));
         }
     }
 
     #[test]
     fn test_inv_mod_xn() {
         type F = TweedledeeBase;
-        let a: Vec<F> = (0..128000).map(|_| F::rand()).collect();
-        let b = inv_mod_xn(&a, 200_000);
-        let m = polynomial_multiplication(&a, &b);
-        assert_eq!(m[0], F::ONE);
-        m[1..200_000].iter().for_each(|&x| {
-            assert_eq!(x, F::ZERO);
-        });
+        let mut rng = thread_rng();
+        let a_deg = rng.gen_range(1, 1_000);
+        let n = rng.gen_range(1, 1_000);
+        let a = Polynomial((0..a_deg).map(|_| F::rand()).collect());
+        let b = a.inv_mod_xn(n);
+        let mut m = a.mul(&b);
+        m.drain(n..);
+        m.trim();
+        assert_eq!(m, Polynomial(vec![F::ONE]));
     }
 
     #[test]
     fn test_polynomial_long_division() {
         type F = TweedledeeBase;
-        let a: Vec<F> = (0..12800).map(|_| F::rand()).collect();
-        let b: Vec<F> = (0..1600).map(|_| F::rand()).collect();
-        let (q, r) = polynomial_long_division(&a, &b);
+        let mut rng = thread_rng();
+        let (a_deg, b_deg) = (rng.gen_range(1, 10_000), rng.gen_range(1, 10_000));
+        let a = Polynomial((0..a_deg).map(|_| F::rand()).collect());
+        let b = Polynomial((0..b_deg).map(|_| F::rand()).collect());
+        let (q, r) = a.polynomial_long_division(&b);
         for _ in 0..1000 {
             let x = F::rand();
-            assert_eq!(
-                evaluate_at_naive(&a, x),
-                evaluate_at_naive(&b, x) * evaluate_at_naive(&q, x) + evaluate_at_naive(&r, x)
-            );
+            assert_eq!(a.eval(x), b.eval(x) * q.eval(x) + r.eval(x));
         }
     }
 
     #[test]
-    fn test_polynomial_division_small() {
+    fn test_polynomial_division() {
         type F = TweedledeeBase;
-        let a: Vec<F> = (0..12_000).map(|_| F::rand()).collect();
-        let b: Vec<F> = (0..1_000).map(|_| F::rand()).collect();
-        let (mut q, mut r) = polynomial_division(&a, &b);
-        assert!(degree(&r) < degree(&b));
-        let (mut ql, mut rl) = polynomial_long_division(&a, &b);
-        trim(&mut q);
-        trim(&mut r);
-        trim(&mut ql);
-        trim(&mut rl);
-        assert_eq!(&q, &ql);
-        assert_eq!(&r, &rl);
+        let mut rng = thread_rng();
+        let (a_deg, b_deg) = (rng.gen_range(1, 10_000), rng.gen_range(1, 10_000));
+        let a = Polynomial((0..a_deg).map(|_| F::rand()).collect());
+        let b = Polynomial((0..b_deg).map(|_| F::rand()).collect());
+        let (q, r) = a.polynomial_division(&b);
         for _ in 0..1000 {
             let x = F::rand();
-            assert_eq!(
-                evaluate_at_naive(&a, x),
-                evaluate_at_naive(&b, x) * evaluate_at_naive(&q, x) + evaluate_at_naive(&r, x)
-            );
-        }
-    }
-
-    #[test]
-    fn test_polynomial_division_large() {
-        type F = TweedledeeBase;
-        let a: Vec<F> = (0..128_000).map(|_| F::rand()).collect();
-        let b: Vec<F> = (0..16_000).map(|_| F::rand()).collect();
-        let now = Instant::now();
-        let (q, r) = polynomial_division(&a, &b);
-        println!("Division time: {:?}", now.elapsed());
-        assert!(degree(&r) < degree(&b));
-        for _ in 0..1000 {
-            let x = F::rand();
-            assert_eq!(
-                evaluate_at_naive(&a, x),
-                evaluate_at_naive(&b, x) * evaluate_at_naive(&q, x) + evaluate_at_naive(&r, x)
-            );
+            assert_eq!(a.eval(x), b.eval(x) * q.eval(x) + r.eval(x));
         }
     }
 
     #[test]
     fn test_division_by_z_h() {
         type F = TweedledeeBase;
-        let mut p: Vec<F> = (0..112_000).map(|_| F::rand()).collect();
-        trim(&mut p);
-        let mut z_h = vec![F::ZERO; 16_001];
-        z_h[16_000] = F::ONE;
-        z_h[0] = F::NEG_ONE;
-        let m = polynomial_multiplication(&p, &z_h);
+        let mut rng = thread_rng();
+        let a_deg = rng.gen_range(1, 10_000);
+        let n = rng.gen_range(1, a_deg);
+        let mut a = Polynomial((0..a_deg).map(|_| F::rand()).collect());
+        a.trim();
+        let z_h = {
+            let mut z_h_vec = vec![F::ZERO; n + 1];
+            z_h_vec[n] = F::ONE;
+            z_h_vec[0] = F::NEG_ONE;
+            Polynomial(z_h_vec)
+        };
+        let m = a.mul(&z_h);
         let now = Instant::now();
-        let mut p_test = divide_by_z_h(&m, 16_000);
-        trim(&mut p_test);
+        let mut a_test = m.divide_by_z_h(n);
+        a_test.trim();
         println!("Division time: {:?}", now.elapsed());
-        assert_eq!(p, p_test);
+        assert_eq!(a, a_test);
     }
 
     // Test to see which polynomial division method is faster for divisions of the type
@@ -324,20 +393,24 @@ mod test {
     #[test]
     fn test_division_linear() {
         type F = TweedledeeBase;
+        let mut rng = thread_rng();
         let l = 14;
         let n = 1 << l;
         let g = F::primitive_root_of_unity(l);
-        let mut xn_minus_one = vec![F::ZERO; n + 1];
-        xn_minus_one[n] = F::ONE;
-        xn_minus_one[0] = F::NEG_ONE;
+        let xn_minus_one = {
+            let mut xn_min_one_vec = vec![F::ZERO; n + 1];
+            xn_min_one_vec[n] = F::ONE;
+            xn_min_one_vec[0] = F::NEG_ONE;
+            Polynomial(xn_min_one_vec)
+        };
 
-        let a = g.exp_u32(1 << (l - 1));
-        let denom = vec![-a, F::ONE];
+        let a = g.exp_usize(rng.gen_range(0, n));
+        let denom = Polynomial(vec![-a, F::ONE]);
         let now = Instant::now();
-        polynomial_division(&xn_minus_one, &denom);
+        xn_minus_one.polynomial_division(&denom);
         println!("Division time: {:?}", now.elapsed());
         let now = Instant::now();
-        polynomial_long_division(&xn_minus_one, &denom);
+        xn_minus_one.polynomial_long_division(&denom);
         println!("Division time: {:?}", now.elapsed());
     }
 }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -83,7 +83,12 @@ impl<F: Field> Polynomial<F> {
     }
 
     pub fn eval_domain(&self, fft_precomputation: &FftPrecomputation<F>) -> Vec<F> {
-        fft_with_precomputation(&self.coeffs(), fft_precomputation)
+        let domain_size = fft_precomputation.size();
+        if self.len() < domain_size {
+            fft_with_precomputation(&self.padded(domain_size).coeffs(), fft_precomputation)
+        } else {
+            fft_with_precomputation(&self.coeffs(), fft_precomputation)
+        }
     }
 
     pub fn from_evaluations(values: &[F], fft_precomputation: &FftPrecomputation<F>) -> Self {
@@ -136,6 +141,12 @@ impl<F: Field> Polynomial<F> {
         self.trim();
         assert!(self.len() <= len);
         self.0.extend((self.len()..len).map(|_| F::ZERO));
+    }
+
+    pub fn padded(&self, len: usize) -> Self {
+        let mut a = self.clone();
+        a.pad(len);
+        a
     }
 
     pub fn mul(&self, b: &Self) -> Self {

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -7,7 +7,7 @@ use crate::halo::verify_ipa;
 use crate::plonk_proof::OldProof;
 use crate::plonk_util::{eval_poly, halo_g, halo_n, halo_n_mul, halo_s, pedersen_hash, powers, reduce_with_powers};
 use crate::util::{ceil_div_usize, log2_strict};
-use crate::{blake_hash_usize_to_curve, fft_precompute, ifft_with_precomputation_power_of_2, msm_execute_parallel, msm_precompute, AffinePoint, Circuit, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, ProjectivePoint, Proof, SchnorrProof, GRID_WIDTH, NUM_ROUTED_WIRES, NUM_WIRES};
+use crate::{blake_hash_usize_to_curve, fft_precompute, ifft_with_precomputation_power_of_2, msm_execute_parallel, msm_precompute, AffinePoint, Circuit, FftPrecomputation, Field, HaloCurve, MsmPrecomputation, Proof, GRID_WIDTH, NUM_ROUTED_WIRES, NUM_WIRES};
 
 pub const SECURITY_BITS: usize = 128;
 

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -327,7 +327,6 @@ fn test_curve_add() -> Result<()> {
     let a = blake_hash_base_field_to_curve::<Tweedledum>(F::rand());
     let b = blake_hash_base_field_to_curve::<Tweedledum>(F::rand());
     let sum = (a + b).to_affine();
-    dbg!(a, b, sum);
 
     let mut builder = CircuitBuilder::<Tweedledee>::new(128);
 

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use plonky::{blake_hash_base_field_to_curve, msm_parallel, rescue_hash_1_to_1, verify_proof, AffinePoint, Base4SumGate, Circuit, CircuitBuilder, Curve, CurveMulOp, Field, HaloCurve, PartialWitness, Target, Tweedledee, Tweedledum, Wire, Witness};
-use rand::{thread_rng, Rng, RngCore};
+use rand::{thread_rng, Rng};
 use std::time::Instant;
 
 // Make sure it's the same as in `plonk.rs`.


### PR DESCRIPTION
This PR adds a `Polynomial` struct that wraps a vector of coefficients. This provides a type-level distinction between polynomials in coefficient vs evaluation form, and more generally between a polynomial and a vector of field elements. It also allows for a more object-oriented design for handling polynomial, e.g. `p.add(&q)` instead of `polynomial_addition(&p, &q)`. 