### PR TITLE
Remove public inputs from proof

### DIFF
--- a/src/bin/recursion.rs
+++ b/src/bin/recursion.rs
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
     let start = Instant::now();
     let old_proofs = vec![];
     let inner_proof = inner_circuit
-        .generate_proof::<Tweedledee>(inner_witness, &old_proofs, true, true)
+        .generate_proof::<Tweedledee>(&inner_witness, &old_proofs, true)
         .unwrap();
     println!("Finished in {}s", start.elapsed().as_secs_f64());
     println!();
@@ -77,20 +77,22 @@ fn main() -> Result<()> {
     let proof = recursion_circuit
         .circuit
         // .generate_proof::<Tweedledum>(recursion_witness, &[inner_proof.into()], true)
-        .generate_proof::<Tweedledum>(recursion_witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&recursion_witness, &[], true)
         .unwrap();
     println!("Finished in {}s", start.elapsed().as_secs_f64());
     println!();
 
     println!("Verifying proof...");
     let start = Instant::now();
-    let pis = proof.get_public_inputs(recursion_circuit.circuit.num_public_inputs);
+    let pis = recursion_circuit
+        .circuit
+        .get_public_inputs(&recursion_witness);
     println!(
         "Number of public inputs: {}",
         recursion_circuit.circuit.num_public_inputs
     );
     let vk = recursion_circuit.circuit.to_vk();
-    verify_proof::<Tweedledee, Tweedledum>(&pis.unwrap(), &proof, &[], &vk, true)?;
+    verify_proof::<Tweedledee, Tweedledum>(&pis, &proof, &[], &vk, true)?;
     println!("Finished in {}s", start.elapsed().as_secs_f64());
     Ok(())
 }

--- a/src/foreign_field.rs
+++ b/src/foreign_field.rs
@@ -1,4 +1,4 @@
-use crate::{HaloCurve, CircuitBuilder, BigIntTarget, Field, field_to_biguint};
+use crate::{field_to_biguint, BigIntTarget, CircuitBuilder, Field, HaloCurve};
 use num::{BigUint, One};
 
 /// Represents an element of a field other than the native field.
@@ -9,7 +9,9 @@ pub struct ForeignFieldTarget {
 
 impl ForeignFieldTarget {
     pub fn zero() -> Self {
-        ForeignFieldTarget { value: BigIntTarget::zero() }
+        ForeignFieldTarget {
+            value: BigIntTarget::zero(),
+        }
     }
 }
 
@@ -23,9 +25,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         &mut self,
         terms: &[ForeignFieldTarget],
     ) -> ForeignFieldTarget {
-        let term_values = terms.iter()
-            .map(|ff| ff.value.clone())
-            .collect::<Vec<_>>();
+        let term_values = terms.iter().map(|ff| ff.value.clone()).collect::<Vec<_>>();
         let sum = self.bigint_add_many(&term_values);
         self.reduce::<FF>(&sum)
     }
@@ -58,8 +58,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CircuitBuilder, PartialWitness, Tweedledum, Field, Curve};
-    use num::{BigUint, FromPrimitive};
+    use crate::{CircuitBuilder, Curve, Field, PartialWitness, Tweedledum};
 
     #[test]
     fn test_foreign_field_add() {

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -333,12 +333,11 @@ impl<C: HaloCurve> Circuit<C> {
         ]
         .concat();
 
-        let opening_points = [vec![
+        let opening_points = vec![
             zeta_sf,
             zeta_sf * self.subgroup_generator_n,
             zeta_sf * self.subgroup_generator_n.exp_usize(GRID_WIDTH),
-        ]]
-        .concat();
+        ];
 
         let halo_proof = batch_opening_proof(
             &all_coeffs.iter().map(|c| &c[..]).collect::<Vec<_>>(),

--- a/src/plonk_proof.rs
+++ b/src/plonk_proof.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 
 use crate::plonk_challenger::Challenger;
 use crate::plonk_util::{halo_g, halo_n, halo_s};
-use crate::{AffinePoint, AffinePointTarget, Curve, Field, HaloCurve, PartialWitness, Target, NUM_WIRES, SECURITY_BITS};
+use crate::{AffinePoint, AffinePointTarget, Curve, Field, HaloCurve, PartialWitness, Target, SECURITY_BITS};
 
 #[derive(Debug, Clone, Copy)]
 pub struct SchnorrProof<C: HaloCurve> {

--- a/src/plonk_proof.rs
+++ b/src/plonk_proof.rs
@@ -26,12 +26,8 @@ pub struct Proof<C: HaloCurve> {
     /// A commitment to the quotient polynomial.
     pub c_plonk_t: Vec<AffinePoint<C>>,
     /// A commitment to the public input quotient polynomial.
-    /// Is `None` iff `o_public_inputs` is `Some`.
-    pub c_pis_quotient: Option<AffinePoint<C>>,
+    pub c_pis_quotient: AffinePoint<C>,
 
-    /// The opening of each polynomial at each `PublicInputGate` index.
-    /// Is `None` iff `c_pis_quotient` is `Some`.
-    pub o_public_inputs: Option<Vec<OpeningSet<C::ScalarField>>>,
     /// The opening of each polynomial at `zeta`.
     pub o_local: OpeningSet<C::ScalarField>,
     /// The opening of each polynomial at `g * zeta`.
@@ -50,28 +46,12 @@ pub struct Proof<C: HaloCurve> {
 }
 
 impl<C: HaloCurve> Proof<C> {
-    pub fn get_public_inputs(&self, count: usize) -> Option<Vec<C::ScalarField>> {
-        self.o_public_inputs.as_ref().map(|pis| {
-            (0..count)
-                .map(|i| {
-                    let pi_gate_idx = i / NUM_WIRES;
-                    let wire_idx = i % NUM_WIRES;
-                    pis[pi_gate_idx].o_wires[wire_idx]
-                })
-                .collect()
-        })
-    }
-
     pub fn all_opening_sets(&self) -> Vec<OpeningSet<C::ScalarField>> {
-        [
-            self.o_public_inputs.as_deref().unwrap_or_default(),
-            &[
-                self.o_local.clone(),
-                self.o_right.clone(),
-                self.o_below.clone(),
-            ],
+        vec![
+            self.o_local.clone(),
+            self.o_right.clone(),
+            self.o_below.clone(),
         ]
-        .concat()
     }
 
     // Computes all challenges used in the proof verification.
@@ -90,13 +70,11 @@ impl<C: HaloCurve> Proof<C> {
         let alpha_bf = challenger.get_challenge();
         let alpha = C::try_convert_b2s(alpha_bf).map_err(|_| anyhow!(error_msg))?;
         challenger.observe_affine_points(&self.c_plonk_t);
-        if let Some(comm) = self.c_pis_quotient {
-            challenger.observe_affine_point(comm);
-            challenger.observe_elements(
-                &C::ScalarField::try_convert_all(public_inputs)
-                    .expect("Public inputs should fit in both fields"),
-            )
-        }
+        challenger.observe_affine_point(self.c_pis_quotient);
+        challenger.observe_elements(
+            &C::ScalarField::try_convert_all(public_inputs)
+                .expect("Public inputs should fit in both fields"),
+        );
         old_proofs
             .iter()
             .for_each(|old_proof| challenger.observe_affine_point(old_proof.halo_g));
@@ -272,18 +250,6 @@ impl ProofTarget {
         witness.set_point_target(self.c_plonk_z, values.c_plonk_z);
         witness.set_point_targets(&self.c_plonk_t, &values.c_plonk_t);
 
-        debug_assert_eq!(
-            self.o_public_inputs.as_ref().map(|pis| pis.len()),
-            values.o_public_inputs.as_ref().map(|pis| pis.len())
-        );
-        if let (Some(values_pis), Some(target_pis)) =
-            (&values.o_public_inputs, &self.o_public_inputs)
-        {
-            for (o_pi_targets, o_pi_values) in target_pis.iter().zip(values_pis) {
-                o_pi_targets.populate_witness(witness, o_pi_values)?;
-            }
-        }
-
         self.o_local.populate_witness(witness, &values.o_local)?;
         self.o_right.populate_witness(witness, &values.o_right)?;
         self.o_below.populate_witness(witness, &values.o_below)?;
@@ -322,8 +288,7 @@ pub struct OpeningSet<F: Field> {
     /// The purported opening of some old proofs `halo_g` polynomials.
     pub o_old_proofs: Vec<F>,
     /// The purported opening of the public input quotient polynomial.
-    /// Is `None` when the prover opens at the public input gates.
-    pub o_pi_quotient: Option<F>,
+    pub o_pi_quotient: F,
 }
 
 impl<F: Field> OpeningSet<F> {
@@ -335,10 +300,7 @@ impl<F: Field> OpeningSet<F> {
             &[self.o_plonk_z],
             self.o_plonk_t.as_slice(),
             self.o_old_proofs.as_slice(),
-            self.o_pi_quotient
-                .map(|o| vec![o])
-                .as_deref()
-                .unwrap_or_default(),
+            &[self.o_pi_quotient],
         ]
         .concat()
     }

--- a/src/plonk_util.rs
+++ b/src/plonk_util.rs
@@ -281,6 +281,24 @@ pub fn sigma_polynomials<F: Field>(
         .collect()
 }
 
+/// Given polynomials `[p_0,...,p_k]` of degree `degree` and `alpha \in F`, returns `\sum_{i=0}^k alpha^i p_i`.
+pub(crate) fn scale_polynomials<F: Field>(
+    polynomials: Vec<Polynomial<F>>,
+    alpha: F,
+    degree: usize,
+) -> Polynomial<F> {
+    let alpha_powers = powers(alpha, polynomials.len());
+    Polynomial::from(
+        (0..degree)
+            .map(|i| {
+                (0..polynomials.len())
+                    .map(|j| polynomials[j][i] * alpha_powers[j])
+                    .fold(F::ZERO, |acc, x| acc + x)
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
 #[allow(dead_code)]
 pub(crate) fn polynomial_degree_plus_1<F: Field>(
     points: &[F],

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -265,8 +265,12 @@ impl<F: Field> Polynomial<F> {
             tmp = tmp.add(&c);
             tmp.iter_mut().for_each(|x| *x = -(*x));
             tmp.trim();
-            let b = &a.mul(&tmp)[..l];
-            a.0.extend_from_slice(b);
+            let mut b = a.mul(&tmp);
+            b.trim();
+            if b.len() > l {
+                b.drain(l..);
+            }
+            a.0.extend_from_slice(&b[..]);
         }
         a.drain(n..);
         a

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -152,6 +152,11 @@ impl<F: Field> Polynomial<F> {
         Self(self.iter().map(|&x| -x).collect())
     }
 
+    /// Multiply the polynomial's coefficients by a scalar.
+    fn scalar_mul(&self, c: F) -> Self {
+        Self(self.iter().map(|&x| c * x).collect())
+    }
+
     /// Removes leading zero coefficients.
     pub fn trim(&mut self) {
         self.0.drain(self.degree_plus_one()..);
@@ -278,6 +283,11 @@ impl<F: Field> Polynomial<F> {
             panic!("Division by zero polynomial");
         } else if a_degree < b_degree {
             (Self::zero(1), self.clone())
+        } else if b_degree == 0 {
+            (
+                self.scalar_mul(b[0].multiplicative_inverse_assuming_nonzero()),
+                Self::empty(),
+            )
         } else {
             let rev_b = b.rev();
             let rev_b_inv = rev_b.inv_mod_xn(a_degree - b_degree + 1);
@@ -419,6 +429,20 @@ mod test {
         let (a_deg, b_deg) = (rng.gen_range(1, 10_000), rng.gen_range(1, 10_000));
         let a = Polynomial((0..a_deg).map(|_| F::rand()).collect());
         let b = Polynomial((0..b_deg).map(|_| F::rand()).collect());
+        let (q, r) = a.polynomial_division(&b);
+        for _ in 0..1000 {
+            let x = F::rand();
+            assert_eq!(a.eval(x), b.eval(x) * q.eval(x) + r.eval(x));
+        }
+    }
+
+    #[test]
+    fn test_polynomial_division_by_constant() {
+        type F = TweedledeeBase;
+        let mut rng = thread_rng();
+        let a_deg = rng.gen_range(1, 10_000);
+        let a = Polynomial((0..a_deg).map(|_| F::rand()).collect());
+        let b = Polynomial::from(vec![F::rand()]);
         let (q, r) = a.polynomial_division(&b);
         for _ in 0..1000 {
             let x = F::rand();

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -136,7 +136,6 @@ pub fn verify_proof<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>>
         verify_all_ipas::<C>(
             &vk.c_constants,
             &vk.c_s_sigmas,
-            vk.num_public_inputs,
             subgroup_generator_n,
             u_curve,
             pedersen_h,
@@ -179,7 +178,6 @@ pub fn verify_proof<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>>
 fn verify_all_ipas<C: HaloCurve>(
     c_constants: &[AffinePoint<C>],
     c_s_sigmas: &[AffinePoint<C>],
-    num_public_inputs: usize,
     subgroup_generator_n: C::ScalarField,
     u_curve: AffinePoint<C>,
     pedersen_h: AffinePoint<C>,

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -1,7 +1,7 @@
 use crate::util::transpose;
-use crate::{AffinePoint, AffinePointTarget, Curve, Field, PublicInput, Target, Wire, NUM_WIRES, OrderingTarget, field_to_biguint, LIMB_BITS, BigIntTarget, biguint_to_limbs, ForeignFieldTarget, biguint_to_field};
+use crate::{biguint_to_field, biguint_to_limbs, field_to_biguint, AffinePoint, AffinePointTarget, BigIntTarget, Curve, Field, ForeignFieldTarget, OrderingTarget, PublicInput, Target, Wire, LIMB_BITS, NUM_WIRES};
+use num::{BigUint, Zero};
 use std::{cmp::Ordering, collections::HashMap};
-use num::{Zero, BigUint};
 
 pub struct PartialWitness<F: Field> {
     wire_values: HashMap<Target, F>,
@@ -64,7 +64,7 @@ impl<F: Field> PartialWitness<F> {
         if lt_eq_gt == &[F::ZERO, F::ZERO, F::ONE] {
             return Ordering::Greater;
         }
-        
+
         panic!("Invalid ordering values")
     }
 
@@ -92,7 +92,8 @@ impl<F: Field> PartialWitness<F> {
 
         debug_assert!(
             value_limbs.len() <= target.limbs.len(),
-            "Not enough limbs to fit the given value");
+            "Not enough limbs to fit the given value"
+        );
 
         while value_limbs.len() < target.limbs.len() {
             value_limbs.push(F::ZERO);

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -234,7 +234,6 @@ fn test_proof_factorial_public_input() -> Result<()> {
 fn test_proof_public_input() -> Result<()> {
     // Set many random public inputs
     let n = thread_rng().gen_range(1, 200);
-    let n = 10;
     let values = (0..n)
         .map(|_| <Tweedledee as Curve>::ScalarField::rand())
         .collect::<Vec<_>>();
@@ -252,10 +251,7 @@ fn test_proof_public_input() -> Result<()> {
         .unwrap();
     let pis = circuit.get_public_inputs(&witness);
     // Check that the public inputs are set correctly in the proof.
-    values
-        .iter()
-        .enumerate()
-        .for_each(|(i, &v)| assert_eq!(v, pis[i]));
+    assert_eq!(values, pis);
     let vk = circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(&values, &proof, &[], &vk, true)?;
 

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -3,9 +3,6 @@ use plonky::{blake_hash_base_field_to_curve, msm_parallel, rescue_hash_1_to_1, v
 use rand::{thread_rng, Rng};
 use std::time::Instant;
 
-// Make sure it's the same as in `plonk.rs`.
-const NUM_WIRES: usize = 9;
-
 fn get_trivial_circuit<C: HaloCurve>(x: C::ScalarField) -> (Circuit<C>, Witness<C::ScalarField>) {
     let mut builder = CircuitBuilder::<C>::new(128);
     let t = builder.constant_wire(x);

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -21,7 +21,7 @@ fn get_trivial_circuit<C: HaloCurve>(x: C::ScalarField) -> (Circuit<C>, Witness<
 fn test_proof_trivial() -> Result<()> {
     let (circuit, witness) = get_trivial_circuit(<Tweedledee as Curve>::ScalarField::ZERO);
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     verify_proof::<Tweedledee, Tweedledum>(&[], &proof, &[], &circuit.into(), true)?;
 
@@ -34,7 +34,7 @@ fn test_proof_trivial_circuit_many_proofs() -> Result<()> {
     for _ in 0..10 {
         let (circuit, witness) = get_trivial_circuit(<Tweedledee as Curve>::ScalarField::ZERO);
         let proof = circuit
-            .generate_proof::<Tweedledum>(witness.clone(), &[], true, true)
+            .generate_proof::<Tweedledum>(&witness, &[], true)
             .unwrap();
         let vk = circuit.to_vk();
         let old_proof = verify_proof::<Tweedledee, Tweedledum>(&[], &proof, &[], &vk, false)
@@ -44,7 +44,7 @@ fn test_proof_trivial_circuit_many_proofs() -> Result<()> {
     }
     let (circuit, witness) = get_trivial_circuit(<Tweedledee as Curve>::ScalarField::ZERO);
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness.clone(), &old_proofs, true, true)
+        .generate_proof::<Tweedledum>(&witness, &old_proofs, true)
         .unwrap();
     let vk = circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(&[], &proof, &old_proofs, &vk, true)?;
@@ -65,7 +65,7 @@ fn test_proof_sum() -> Result<()> {
     let circuit = builder.build();
     let witness = circuit.generate_witness(partial_witness);
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let vk = circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(&[], &proof, &[], &vk, true)?;
@@ -96,7 +96,7 @@ fn test_proof_sum_big() -> Result<()> {
     let witness = circuit.generate_witness(partial_witness);
     dbg!(now.elapsed());
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     dbg!(now.elapsed());
     let vk = circuit.to_vk();
@@ -122,7 +122,7 @@ fn test_proof_quadratic() -> Result<()> {
     let circuit = builder.build();
     let witness = circuit.generate_witness(partial_witness);
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let vk = circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(&[], &proof, &[], &vk, true)?;
@@ -149,7 +149,7 @@ fn test_proof_quadratic_public_input() -> Result<()> {
     let circuit = builder.build();
     let witness = circuit.generate_witness(partial_witness);
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, false)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let vk = circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(&[F::from_canonical_usize(7)], &proof, &[], &vk, true)?;
@@ -179,7 +179,7 @@ fn test_proof_sum_public_input() -> Result<()> {
     let witness = circuit.generate_witness(partial_witness);
     let now = Instant::now();
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, false)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     dbg!(now.elapsed());
     let vk = circuit.to_vk();
@@ -216,7 +216,7 @@ fn test_proof_factorial_public_input() -> Result<()> {
     let circuit = builder.build();
     let witness = circuit.generate_witness(partial_witness);
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, false)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let vk = circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(
@@ -231,43 +231,10 @@ fn test_proof_factorial_public_input() -> Result<()> {
 }
 
 #[test]
-fn test_proof_public_input1() -> Result<()> {
-    // Set public inputs pi1 = 2 and check that pi1 - 2 == 0.
-    let mut builder = CircuitBuilder::<Tweedledee>::new(128);
-    let pi = builder.stage_public_input();
-    builder.route_public_inputs();
-    let t1 = pi.routable_target();
-    let t2 = builder.constant_wire(<Tweedledee as Curve>::ScalarField::TWO);
-    let t3 = builder.sub(t1, t2);
-    builder.assert_zero(t3);
-    let mut partial_witness = PartialWitness::new();
-    partial_witness.set_target(t1, <Tweedledee as Curve>::ScalarField::TWO);
-    let circuit = builder.build();
-    let witness = circuit.generate_witness(partial_witness);
-    let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
-        .unwrap();
-    // Check that the public input is set correctly in the proof.
-    assert_eq!(
-        proof.o_public_inputs.as_ref().unwrap()[0].o_wires[0],
-        <Tweedledee as Curve>::ScalarField::TWO
-    );
-    let vk = circuit.to_vk();
-    verify_proof::<Tweedledee, Tweedledum>(
-        &[<Tweedledee as Curve>::ScalarField::TWO],
-        &proof,
-        &[],
-        &vk,
-        true,
-    )?;
-
-    Ok(())
-}
-
-#[test]
-fn test_proof_public_input2() -> Result<()> {
+fn test_proof_public_input() -> Result<()> {
     // Set many random public inputs
-    let n = 200;
+    let n = thread_rng().gen_range(1, 200);
+    let n = 10;
     let values = (0..n)
         .map(|_| <Tweedledee as Curve>::ScalarField::rand())
         .collect::<Vec<_>>();
@@ -281,15 +248,14 @@ fn test_proof_public_input2() -> Result<()> {
     let circuit = builder.build();
     let witness = circuit.generate_witness(partial_witness);
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
+    let pis = circuit.get_public_inputs(&witness);
     // Check that the public inputs are set correctly in the proof.
-    values.iter().enumerate().for_each(|(i, &v)| {
-        assert_eq!(
-            v,
-            proof.o_public_inputs.as_ref().unwrap()[i / NUM_WIRES].o_wires[i % NUM_WIRES],
-        )
-    });
+    values
+        .iter()
+        .enumerate()
+        .for_each(|(i, &v)| assert_eq!(v, pis[i]));
     let vk = circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(&values, &proof, &[], &vk, true)?;
 
@@ -312,7 +278,7 @@ fn test_rescue_hash() -> Result<()> {
     let circuit = builder.build();
     let witness = circuit.generate_witness(partial_witness);
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let vk = circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(&[], &proof, &[], &vk, true)?;
@@ -344,7 +310,7 @@ fn test_curve_add() -> Result<()> {
     let witness = circuit.generate_witness(partial_witness);
 
     let proof = circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
 
     let vk = circuit.to_vk();
@@ -388,7 +354,7 @@ fn test_curve_msm() -> Result<()> {
     let circuit = builder.build();
     let witness = circuit.generate_witness(partial_witness);
     let proof = circuit
-        .generate_proof::<Tweedledee>(witness, &[], true, true)
+        .generate_proof::<Tweedledee>(&witness, &[], true)
         .unwrap();
 
     let vk = circuit.to_vk();
@@ -441,14 +407,19 @@ fn test_base_4_sum() -> Result<()> {
     );
 
     let t_limbs = (0..B4::NUM_LIMBS)
-        .map(|i| Target::Wire(Wire { gate: index, input: B4::wire_limb(i) }))
+        .map(|i| {
+            Target::Wire(Wire {
+                gate: index,
+                input: B4::wire_limb(i),
+            })
+        })
         .collect::<Vec<_>>();
 
     let circuit = builder.build();
     let mut partial_witness = PartialWitness::new();
     partial_witness.set_targets(&t_limbs, &limbs);
     let witness = circuit.generate_witness(partial_witness);
-    let proof = circuit.generate_proof::<InnerC>(witness, &[], false, true)?;
+    let proof = circuit.generate_proof::<Tweedledum>(&witness, &[], true)?;
     verify_proof::<C, InnerC>(&[], &proof, &[], &circuit.into(), true)?;
 
     Ok(())
@@ -472,7 +443,7 @@ fn test_curve_double_gate() -> Result<()> {
 
     let circuit = builder.build();
     let witness = circuit.generate_witness(PartialWitness::new());
-    let proof = circuit.generate_proof::<InnerC>(witness, &[], false, true)?;
+    let proof = circuit.generate_proof::<Tweedledum>(&witness, &[], true)?;
     verify_proof::<C, InnerC>(&[], &proof, &[], &circuit.into(), true)?;
 
     Ok(())

--- a/tests/prove_and_verify_recursive.rs
+++ b/tests/prove_and_verify_recursive.rs
@@ -12,7 +12,7 @@ fn test_proof_trivial_recursive() -> Result<()> {
     let inner_circuit = builder.build();
     let witness = inner_circuit.generate_witness(partial_witness);
     let inner_proof = inner_circuit
-        .generate_proof::<Tweedledum>(witness, &[], true, true)
+        .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let inner_vk = inner_circuit.to_vk();
     verify_proof::<Tweedledee, Tweedledum>(&[], &inner_proof, &[], &inner_vk, true)?;
@@ -33,7 +33,7 @@ fn test_proof_trivial_recursive() -> Result<()> {
     let recursion_witness = recursion_circuit.circuit.generate_witness(recursion_inputs);
     let proof = recursion_circuit
         .circuit
-        .generate_proof::<Tweedledee>(recursion_witness, &[], true, true)
+        .generate_proof::<Tweedledee>(&recursion_witness, &[], true)
         .unwrap();
     let vk = recursion_circuit.circuit.to_vk();
     verify_proof::<Tweedledum, Tweedledee>(&[], &proof, &[], &vk, true)?;


### PR DESCRIPTION
This PR removes the `output_pis` flag used currently in the prover so that proofs no longer contain the openings at the public input gates.
Note: I haven't modified `ProofTarget` yet.