### PR TITLE
Typed targets

### DIFF
--- a/src/circuit_bigint.rs
+++ b/src/circuit_bigint.rs
@@ -10,7 +10,7 @@ use num::{BigUint, Integer, One, Zero};
 pub(crate) const LIMB_DIBITS: usize = 43;
 pub(crate) const LIMB_BITS: usize = LIMB_DIBITS * 2;
 
-/// Targets representing an unsigned big integer.
+/// Targets representing an unsigned big integer with limbs defined over a field `F`.
 #[derive(Clone)]
 pub struct BigIntTarget<F: Field> {
     pub limbs: Vec<Target<F>>,

--- a/src/circuit_curve.rs
+++ b/src/circuit_curve.rs
@@ -227,7 +227,6 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>>
             WitnessGenerator<InnerC::BaseField> for ResultGenerator<C, InnerC>
         {
-            // fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
             fn dependencies(&self) -> Vec<Target<InnerC::BaseField>> {
                 vec![
                     self.mul.scalar.convert::<InnerC::BaseField>(),

--- a/src/circuit_curve.rs
+++ b/src/circuit_curve.rs
@@ -14,7 +14,9 @@ impl<C: Curve> AffinePointTarget<C> {
     }
 }
 
-/// Represents a scalar * point multiplication operation.
+/// Represents a scalar * point multiplication operation on `InnerC`.
+/// `scalar` is modelled here in the "wrong" field `InnerC::BaseField = C::ScalarField` for coherence.
+/// Thus, all scalar operations should be done preemptively in the correct field `InnerC::ScalarField = C::BaseField".
 pub struct CurveMulOp<C: Curve, InnerC: Curve<BaseField = C::ScalarField>> {
     pub scalar: Target<C::ScalarField>,
     pub point: AffinePointTarget<InnerC>,

--- a/src/circuit_curve.rs
+++ b/src/circuit_curve.rs
@@ -1,43 +1,43 @@
-use crate::{HaloCurve, CircuitBuilder, Target, Curve, AffinePoint, CurveAddGate, BufferGate, Wire, WitnessGenerator, PartialWitness, Field, blake_hash_base_field_to_curve, CurveDblGate, CurveEndoGate, Base4SumGate};
-use std::marker::PhantomData;
 use crate::plonk_util::halo_n;
+use crate::{blake_hash_base_field_to_curve, AffinePoint, Base4SumGate, BufferGate, CircuitBuilder, Curve, CurveAddGate, CurveDblGate, CurveEndoGate, Field, HaloCurve, PartialWitness, Target, Wire, WitnessGenerator};
+use std::marker::PhantomData;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct AffinePointTarget {
-    pub x: Target,
-    pub y: Target,
+pub struct AffinePointTarget<C: Curve> {
+    pub x: Target<C::BaseField>,
+    pub y: Target<C::BaseField>,
 }
 
-impl AffinePointTarget {
-    pub fn to_vec(&self) -> Vec<Target> {
+impl<C: Curve> AffinePointTarget<C> {
+    pub fn to_vec(&self) -> Vec<Target<C::BaseField>> {
         vec![self.x, self.y]
     }
 }
 
 /// Represents a scalar * point multiplication operation.
-pub struct CurveMulOp {
-    pub scalar: Target,
-    pub point: AffinePointTarget,
+pub struct CurveMulOp<C: Curve, InnerC: Curve<BaseField = C::ScalarField>> {
+    pub scalar: Target<C::ScalarField>,
+    pub point: AffinePointTarget<InnerC>,
 }
 
-pub struct CurveMulEndoResult {
-    pub mul_result: AffinePointTarget,
-    pub actual_scalar: Target,
+pub struct CurveMulEndoResult<C: Curve, InnerC: Curve<BaseField = C::ScalarField>> {
+    pub mul_result: AffinePointTarget<InnerC>,
+    pub actual_scalar: Target<C::ScalarField>,
 }
 
-pub struct CurveMsmEndoResult {
-    pub msm_result: AffinePointTarget,
+pub struct CurveMsmEndoResult<C: Curve, InnerC: Curve<BaseField = C::ScalarField>> {
+    pub msm_result: AffinePointTarget<InnerC>,
     /// While `msm` computes a sum of `[s] P` terms, `msm_endo` computes a sum of `[n(s)] P` terms
     /// for some injective `n`. Here we return each `n(s)`, i.e., the scalar by which the point was
     /// actually multiplied.
-    pub actual_scalars: Vec<Target>,
+    pub actual_scalars: Vec<Target<C::ScalarField>>,
 }
 
 impl<C: HaloCurve> CircuitBuilder<C> {
     pub fn constant_affine_point<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
         point: AffinePoint<InnerC>,
-    ) -> AffinePointTarget {
+    ) -> AffinePointTarget<InnerC> {
         assert!(!point.zero);
         AffinePointTarget {
             x: self.constant_wire(point.x),
@@ -46,10 +46,10 @@ impl<C: HaloCurve> CircuitBuilder<C> {
     }
 
     /// Add a copy constraint between two affine targets.
-    pub fn copy_curve(
+    pub fn copy_curve<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
-        affine_target_1: AffinePointTarget,
-        affine_target_2: AffinePointTarget,
+        affine_target_1: AffinePointTarget<InnerC>,
+        affine_target_2: AffinePointTarget<InnerC>,
     ) {
         self.copy(affine_target_1.x, affine_target_2.x);
         self.copy(affine_target_1.y, affine_target_2.y);
@@ -58,7 +58,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
     /// Assert that a given coordinate pair is on the curve `C`.
     pub fn curve_assert_valid<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
-        p: AffinePointTarget,
+        p: AffinePointTarget<InnerC>,
     ) {
         // Recall the short Weierstrass equation: y^2 = x^3 + a*x + b.
         let a = self.constant_wire(InnerC::A);
@@ -72,17 +72,17 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
     pub fn curve_neg<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
-        p: AffinePointTarget,
-    ) -> AffinePointTarget {
+        p: AffinePointTarget<InnerC>,
+    ) -> AffinePointTarget<InnerC> {
         let neg_y = self.neg(p.y);
         AffinePointTarget { x: p.x, y: neg_y }
     }
 
     pub fn curve_add<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
-        p_1: AffinePointTarget,
-        p_2: AffinePointTarget,
-    ) -> AffinePointTarget {
+        p_1: AffinePointTarget<InnerC>,
+        p_2: AffinePointTarget<InnerC>,
+    ) -> AffinePointTarget<InnerC> {
         // Add a CurveAddGate, then add a BufferGate to receive the updated accumulator state.
         let add_index = self.num_gates();
         self.add_gate_no_constants(CurveAddGate::<C, InnerC>::new(add_index));
@@ -149,8 +149,8 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
     pub fn curve_double<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
-        p: AffinePointTarget,
-    ) -> AffinePointTarget {
+        p: AffinePointTarget<InnerC>,
+    ) -> AffinePointTarget<InnerC> {
         let idx_dbl = self.num_gates();
         self.add_gate_no_constants(CurveDblGate::<C, InnerC>::new(idx_dbl));
         self.copy(
@@ -181,25 +181,25 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
     pub fn curve_sub<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
-        p_1: AffinePointTarget,
-        p_2: AffinePointTarget,
-    ) -> AffinePointTarget {
+        p_1: AffinePointTarget<InnerC>,
+        p_2: AffinePointTarget<InnerC>,
+    ) -> AffinePointTarget<InnerC> {
         let neg_p_2 = self.curve_neg::<InnerC>(p_2);
         self.curve_add::<InnerC>(p_1, neg_p_2)
     }
 
     pub fn curve_mul<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
-        mul: CurveMulOp,
-    ) -> AffinePointTarget {
+        mul: CurveMulOp<C, InnerC>,
+    ) -> AffinePointTarget<InnerC> {
         self.curve_msm::<InnerC>(&[mul])
     }
 
     /// Computes `[n(s)] p`.
     pub fn curve_mul_endo<InnerC: HaloCurve<BaseField = C::ScalarField>>(
         &mut self,
-        mul: CurveMulOp,
-    ) -> CurveMulEndoResult {
+        mul: CurveMulOp<C, InnerC>,
+    ) -> CurveMulEndoResult<C, InnerC> {
         let result = self.curve_msm_endo::<InnerC>(&[mul]);
         CurveMulEndoResult {
             mul_result: result.msm_result,
@@ -210,21 +210,28 @@ impl<C: HaloCurve> CircuitBuilder<C> {
     /// Computes `[1 / n(s)] p`.
     pub fn curve_mul_inv_endo<InnerC: HaloCurve<BaseField = C::ScalarField>>(
         &mut self,
-        mul: CurveMulOp,
-    ) -> CurveMulEndoResult {
+        mul: CurveMulOp<C, InnerC>,
+    ) -> CurveMulEndoResult<C, InnerC> {
         // We witness r = [1 / n(s)] p, then verify that [n(s)] r = p, and return r.
         let CurveMulOp { scalar, point } = mul;
 
-        struct ResultGenerator<InnerC: HaloCurve> {
-            mul: CurveMulOp,
-            result: AffinePointTarget,
+        struct ResultGenerator<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>> {
+            mul: CurveMulOp<C, InnerC>,
+            result: AffinePointTarget<InnerC>,
             security_bits: usize,
-            _phantom: PhantomData<InnerC>,
+            _phantom: PhantomData<C>,
         }
 
-        impl<InnerC: HaloCurve> WitnessGenerator<InnerC::BaseField> for ResultGenerator<InnerC> {
-            fn dependencies(&self) -> Vec<Target> {
-                vec![self.mul.scalar, self.mul.point.x, self.mul.point.y]
+        impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>>
+            WitnessGenerator<InnerC::BaseField> for ResultGenerator<C, InnerC>
+        {
+            // fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
+            fn dependencies(&self) -> Vec<Target<InnerC::BaseField>> {
+                vec![
+                    self.mul.scalar.convert::<InnerC::BaseField>(),
+                    self.mul.point.x,
+                    self.mul.point.y,
+                ]
             }
 
             fn generate(
@@ -233,7 +240,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
                 witness: &PartialWitness<InnerC::BaseField>,
             ) -> PartialWitness<InnerC::BaseField> {
                 let scalar = witness
-                    .get_target(self.mul.scalar)
+                    .get_target(self.mul.scalar.convert())
                     .try_convert::<InnerC::ScalarField>()
                     .expect("Improbable");
                 let scalar_bits = &scalar.to_canonical_bool_vec()[..self.security_bits];
@@ -252,7 +259,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         }
 
         let result = self.add_virtual_point_target();
-        self.add_generator(ResultGenerator::<InnerC> {
+        self.add_generator(ResultGenerator::<C, InnerC> {
             mul,
             result,
             security_bits: self.security_bits,
@@ -277,14 +284,14 @@ impl<C: HaloCurve> CircuitBuilder<C> {
     /// uniformly random.
     pub fn curve_msm<InnerC: Curve<BaseField = C::ScalarField>>(
         &mut self,
-        parts: &[CurveMulOp],
-    ) -> AffinePointTarget {
+        parts: &[CurveMulOp<C, InnerC>],
+    ) -> AffinePointTarget<InnerC> {
         // We assume each most significant bit is unset; see the note in the method doc.
         let f_bits = C::ScalarField::BITS - 1;
 
-        let all_bits: Vec<Vec<Target>> = parts
+        let all_bits: Vec<Vec<Target<C::ScalarField>>> = parts
             .iter()
-            .map(|part| self.split_binary(part.scalar, f_bits))
+            .map(|part| self.split_binary(part.scalar.convert(), f_bits))
             .collect();
 
         // Normally we would start with zero, but to avoid exceptional cases, we start with some
@@ -394,7 +401,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
         // Assert that each accumulation of scalar bits matches the original scalar.
         for (j, part) in parts.iter().enumerate() {
-            self.copy(scalar_accs[j], part.scalar);
+            self.copy(scalar_accs[j], part.scalar.convert());
         }
 
         acc
@@ -403,8 +410,8 @@ impl<C: HaloCurve> CircuitBuilder<C> {
     /// Like `curve_msm`, but uses the endomorphism described in the Halo paper.
     pub fn curve_msm_endo<InnerC: HaloCurve<BaseField = C::ScalarField>>(
         &mut self,
-        parts: &[CurveMulOp],
-    ) -> CurveMsmEndoResult {
+        parts: &[CurveMulOp<C, InnerC>],
+    ) -> CurveMsmEndoResult<C, InnerC> {
         let zero = self.zero_wire();
 
         // We assume each most significant bit is unset; see the note in curve_msm's method doc.
@@ -420,9 +427,14 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         // We split each scalar into 128 bits and 63 dibits. The bits are used in the MSM, while the
         // dibits are ignored, except that we need to include them in our sum-of-limbs computation
         // in order to verify that the decomposition was correct.
-        let (all_bits, all_dibits): (Vec<Vec<Target>>, Vec<Vec<Target>>) = parts
+        let (all_bits, all_dibits): (
+            Vec<Vec<Target<C::ScalarField>>>,
+            Vec<Vec<Target<C::ScalarField>>>,
+        ) = parts
             .iter()
-            .map(|part| self.split_binary_and_base_4(part.scalar, scalar_bits, scalar_dibits))
+            .map(|part| {
+                self.split_binary_and_base_4(part.scalar.convert(), scalar_bits, scalar_dibits)
+            })
             .unzip();
 
         // Normally we would start with zero, but to avoid exceptional cases, we start with some
@@ -604,7 +616,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
         // Finally, assert that each unsigned accumulator matches the original scalar.
         for (j, part) in parts.iter().enumerate() {
-            self.copy(scalar_acc_unsigned[j], part.scalar);
+            self.copy(scalar_acc_unsigned[j], part.scalar.convert());
         }
 
         CurveMsmEndoResult {

--- a/src/curve/curve.rs
+++ b/src/curve/curve.rs
@@ -45,6 +45,14 @@ pub trait Curve: 'static + Sync + Sized + Copy + Debug {
         }
         Ok(res)
     }
+
+    fn try_convert_b2s_slice(s: &[Self::BaseField]) -> Result<Vec<Self::ScalarField>> {
+        let mut res = Vec::with_capacity(s.len());
+        for &x in s {
+            res.push(Self::try_convert_b2s(x)?);
+        }
+        Ok(res)
+    }
 }
 
 /// A curve with the endomorphism described in the Halo paper, i.e. `phi((x, y)) = (zeta_p x, y)`,

--- a/src/curve/curve.rs
+++ b/src/curve/curve.rs
@@ -37,6 +37,14 @@ pub trait Curve: 'static + Sync + Sized + Copy + Debug {
     fn try_convert_s2b(x: Self::ScalarField) -> Result<Self::BaseField> {
         x.try_convert::<Self::BaseField>()
     }
+
+    fn try_convert_s2b_slice(s: &[Self::ScalarField]) -> Result<Vec<Self::BaseField>> {
+        let mut res = Vec::with_capacity(s.len());
+        for &x in s {
+            res.push(Self::try_convert_s2b(x)?);
+        }
+        Ok(res)
+    }
 }
 
 /// A curve with the endomorphism described in the Halo paper, i.e. `phi((x, y)) = (zeta_p x, y)`,
@@ -44,7 +52,6 @@ pub trait Curve: 'static + Sync + Sized + Copy + Debug {
 pub trait HaloCurve: Curve {
     const ZETA: Self::BaseField;
     const ZETA_SCALAR: Self::ScalarField;
-
 }
 
 /// A point on a short Weierstrass curve, represented in affine coordinates.
@@ -229,7 +236,7 @@ impl<C: Curve> ProjectivePoint<C> {
             x: self.x,
             y: -self.y,
             z: self.z,
-            zero: self.zero
+            zero: self.zero,
         }
     }
 }

--- a/src/gates/arithmetic.rs
+++ b/src/gates/arithmetic.rs
@@ -50,11 +50,11 @@ impl<C: HaloCurve> Gate<C> for ArithmeticGate<C> {
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        _right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        _right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         let const_0 = local_constant_values[Self::PREFIX.len()];
         let const_1 = local_constant_values[Self::PREFIX.len() + 1];
         let multiplicand_0 = local_wire_values[Self::WIRE_MULTIPLICAND_0];
@@ -70,7 +70,7 @@ impl<C: HaloCurve> Gate<C> for ArithmeticGate<C> {
 }
 
 impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for ArithmeticGate<C> {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         vec![
             Target::Wire(Wire {
                 gate: self.index,

--- a/src/gates/base_4_sum.rs
+++ b/src/gates/base_4_sum.rs
@@ -63,16 +63,16 @@ impl<C: HaloCurve> Gate<C> for Base4SumGate<C> {
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        _local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        _right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        _local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        _right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         let four = builder.constant_wire_u32(4);
 
         let acc_old = local_wire_values[Self::WIRE_ACC_OLD];
         let acc_new = local_wire_values[Self::WIRE_ACC_NEW];
-        let limbs: Vec<Target> = (0..Self::NUM_LIMBS)
+        let limbs: Vec<Target<C::ScalarField>> = (0..Self::NUM_LIMBS)
             .map(|i| local_wire_values[Self::wire_limb(i)])
             .collect();
 
@@ -97,7 +97,7 @@ impl<C: HaloCurve> Gate<C> for Base4SumGate<C> {
 }
 
 impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for Base4SumGate<C> {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         Vec::new()
     }
 

--- a/src/gates/buffer.rs
+++ b/src/gates/buffer.rs
@@ -37,17 +37,17 @@ impl<C: HaloCurve> Gate<C> for BufferGate<C> {
 
     fn evaluate_unfiltered_recursively(
         _builder: &mut CircuitBuilder<C>,
-        _local_constant_values: &[Target],
-        _local_wire_values: &[Target],
-        _right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        _local_constant_values: &[Target<C::ScalarField>],
+        _local_wire_values: &[Target<C::ScalarField>],
+        _right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         Vec::new()
     }
 }
 
 impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for BufferGate<C> {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         Vec::new()
     }
 

--- a/src/gates/constant.rs
+++ b/src/gates/constant.rs
@@ -38,11 +38,11 @@ impl<C: HaloCurve> Gate<C> for ConstantGate<C> {
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        _right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        _right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         let c = local_constant_values[Self::PREFIX.len()];
         let out = local_wire_values[Self::WIRE_OUTPUT];
         vec![builder.sub(c, out)]
@@ -50,7 +50,7 @@ impl<C: HaloCurve> Gate<C> for ConstantGate<C> {
 }
 
 impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for ConstantGate<C> {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         Vec::new()
     }
 

--- a/src/gates/curve_add.rs
+++ b/src/gates/curve_add.rs
@@ -86,11 +86,11 @@ impl<C: HaloCurve, InnerC: Curve<BaseField = C::ScalarField>> Gate<C> for CurveA
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        _local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        _local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         // Notation:
         // - p1 is the accumulator;
         // - p2 is the addend;
@@ -145,7 +145,7 @@ impl<C: HaloCurve, InnerC: Curve<BaseField = C::ScalarField>> Gate<C> for CurveA
 impl<C: HaloCurve, InnerC: Curve<BaseField = C::ScalarField>> WitnessGenerator<C::ScalarField>
     for CurveAddGate<C, InnerC>
 {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         vec![
             Target::Wire(Wire {
                 gate: self.index,

--- a/src/gates/curve_dbl.rs
+++ b/src/gates/curve_dbl.rs
@@ -64,11 +64,11 @@ impl<C: HaloCurve, InnerC: Curve<BaseField = C::ScalarField>> Gate<C> for CurveD
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        _local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        _right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        _local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        _right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         let _one = builder.one_wire();
         let three = builder.constant_wire_u32(3);
         let a = builder.constant_wire(InnerC::A);
@@ -108,7 +108,7 @@ impl<C: HaloCurve, InnerC: Curve<BaseField = C::ScalarField>> Gate<C> for CurveD
 impl<C: HaloCurve, InnerC: Curve<BaseField = C::ScalarField>> WitnessGenerator<C::ScalarField>
     for CurveDblGate<C, InnerC>
 {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         vec![
             Target::Wire(Wire {
                 gate: self.index,

--- a/src/gates/curve_endo.rs
+++ b/src/gates/curve_endo.rs
@@ -76,9 +76,8 @@ impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>> Gate<C>
         vec![
             computed_x3 - x3,
             computed_y3 - y3,
-            scalar_acc_unsigned_new - (scalar_acc_unsigned_old.quadruple()
-                + scalar_bit_1.double()
-                + scalar_bit_0),
+            scalar_acc_unsigned_new
+                - (scalar_acc_unsigned_old.quadruple() + scalar_bit_1.double() + scalar_bit_0),
             scalar_acc_signed_new - (scalar_acc_signed_old.double() + signed_limb),
             scalar_bit_0 * (scalar_bit_0 - one),
             scalar_bit_1 * (scalar_bit_1 - one),
@@ -88,11 +87,11 @@ impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>> Gate<C>
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        _local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        right_wire_values: &[Target],
-        below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        _local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        right_wire_values: &[Target<C::ScalarField>],
+        below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         let one = builder.one_wire();
         let two = builder.two_wire();
         let four = builder.constant_wire_u32(4);
@@ -156,7 +155,7 @@ impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>> Gate<C>
 impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>> WitnessGenerator<C::ScalarField>
     for CurveEndoGate<C, InnerC>
 {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         vec![
             Target::Wire(Wire {
                 gate: self.index,

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -129,11 +129,11 @@ pub fn evaluate_all_constraints_recursively<
     InnerC: HaloCurve<BaseField = C::ScalarField>,
 >(
     builder: &mut CircuitBuilder<C>,
-    local_constant_values: &[Target],
-    local_wire_values: &[Target],
-    right_wire_values: &[Target],
-    below_wire_values: &[Target],
-) -> Vec<Target> {
+    local_constant_values: &[Target<C::ScalarField>],
+    local_wire_values: &[Target<C::ScalarField>],
+    right_wire_values: &[Target<C::ScalarField>],
+    below_wire_values: &[Target<C::ScalarField>],
+) -> Vec<Target<C::ScalarField>> {
     let constraint_sets_per_gate = vec![
         CurveAddGate::<C, InnerC>::evaluate_filtered_recursively(
             builder,
@@ -220,7 +220,10 @@ pub fn evaluate_all_constraints_recursively<
 }
 
 /// Computes `x * (x - 1)`, which should vanish iff `x` is binary.
-fn assert_binary_recursively<C: HaloCurve>(builder: &mut CircuitBuilder<C>, x: Target) -> Target {
+fn assert_binary_recursively<C: HaloCurve>(
+    builder: &mut CircuitBuilder<C>,
+    x: Target<C::ScalarField>,
+) -> Target<C::ScalarField> {
     let one = builder.one_wire();
     let x_minus_one = builder.sub(x, one);
     builder.mul(x, x_minus_one)
@@ -229,9 +232,9 @@ fn assert_binary_recursively<C: HaloCurve>(builder: &mut CircuitBuilder<C>, x: T
 /// Computes `x * y - 1`, which should vanish iff `x` and `y` are inverses.
 fn assert_inverses_recursively<C: HaloCurve>(
     builder: &mut CircuitBuilder<C>,
-    x: Target,
-    y: Target,
-) -> Target {
+    x: Target<C::ScalarField>,
+    y: Target<C::ScalarField>,
+) -> Target<C::ScalarField> {
     let one = builder.one_wire();
     let x_y = builder.mul(x, y);
     builder.sub(x_y, one)
@@ -262,11 +265,11 @@ pub trait Gate<C: HaloCurve>: WitnessGenerator<C::ScalarField> {
 
     fn evaluate_filtered_recursively(
         builder: &mut CircuitBuilder<C>,
-        local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        right_wire_values: &[Target],
-        below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        right_wire_values: &[Target<C::ScalarField>],
+        below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         let filter = Self::evaluate_prefix_filter_recursively(builder, local_constant_values);
         let unfiltered = Self::evaluate_unfiltered_recursively(
             builder,
@@ -296,8 +299,8 @@ pub trait Gate<C: HaloCurve>: WitnessGenerator<C::ScalarField> {
 
     fn evaluate_prefix_filter_recursively(
         builder: &mut CircuitBuilder<C>,
-        local_constant_values: &[Target],
-    ) -> Target {
+        local_constant_values: &[Target<C::ScalarField>],
+    ) -> Target<C::ScalarField> {
         let one = builder.one_wire();
         let mut product = one;
         for (i, &bit) in Self::PREFIX.iter().enumerate() {
@@ -322,11 +325,11 @@ pub trait Gate<C: HaloCurve>: WitnessGenerator<C::ScalarField> {
     /// Like the other `evaluate` method, but in the context of a recursive circuit.
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        right_wire_values: &[Target],
-        below_wire_values: &[Target],
-    ) -> Vec<Target>;
+        local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        right_wire_values: &[Target<C::ScalarField>],
+        below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>>;
 }
 
 /// Test that a gate's constraints are within degree 8n, including the gate prefix filter.

--- a/src/gates/public_input.rs
+++ b/src/gates/public_input.rs
@@ -44,11 +44,11 @@ impl<C: HaloCurve> Gate<C> for PublicInputGate<C> {
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        _local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
+        _local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
         // This ensures that advice wires' values are copied to the following buffer gate.
         // TODO: Consider enforcing this via copy constraints, in which case there would be nothing to do here.
         (0..NUM_ADVICE_WIRES)
@@ -63,7 +63,7 @@ impl<C: HaloCurve> Gate<C> for PublicInputGate<C> {
 }
 
 impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for PublicInputGate<C> {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         (0..NUM_WIRES)
             .map(|i| {
                 Target::Wire(Wire {
@@ -80,7 +80,7 @@ impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for PublicInputGate<C> {
         witness: &PartialWitness<C::ScalarField>,
     ) -> PartialWitness<C::ScalarField> {
         let self_as_generator: &dyn WitnessGenerator<C::ScalarField> = self;
-        let targets: Vec<Target> = self_as_generator.dependencies();
+        let targets: Vec<Target<C::ScalarField>> = self_as_generator.dependencies();
 
         let mut result = PartialWitness::new();
         for i_advice in 0..NUM_ADVICE_WIRES {

--- a/src/gates/rescue_a.rs
+++ b/src/gates/rescue_a.rs
@@ -66,20 +66,20 @@ impl<C: HaloCurve> Gate<C> for RescueStepAGate<C> {
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
-        let ins: Vec<Target> = (0..RESCUE_SPONGE_WIDTH)
+        local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
+        let ins: Vec<Target<C::ScalarField>> = (0..RESCUE_SPONGE_WIDTH)
             .map(|i| local_wire_values[Self::wire_acc(i)])
             .collect();
 
-        let outs: Vec<Target> = (0..RESCUE_SPONGE_WIDTH)
+        let outs: Vec<Target<C::ScalarField>> = (0..RESCUE_SPONGE_WIDTH)
             .map(|i| right_wire_values[Self::wire_acc(i)])
             .collect();
 
-        let roots: Vec<Target> = (0..RESCUE_SPONGE_WIDTH)
+        let roots: Vec<Target<C::ScalarField>> = (0..RESCUE_SPONGE_WIDTH)
             .map(|i| local_wire_values[Self::wire_root(i)])
             .collect();
 
@@ -102,7 +102,7 @@ impl<C: HaloCurve> Gate<C> for RescueStepAGate<C> {
 }
 
 impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for RescueStepAGate<C> {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         (0..RESCUE_SPONGE_WIDTH)
             .map(|i| {
                 Target::Wire(Wire {

--- a/src/gates/rescue_b.rs
+++ b/src/gates/rescue_b.rs
@@ -59,21 +59,21 @@ impl<C: HaloCurve> Gate<C> for RescueStepBGate<C> {
 
     fn evaluate_unfiltered_recursively(
         builder: &mut CircuitBuilder<C>,
-        local_constant_values: &[Target],
-        local_wire_values: &[Target],
-        right_wire_values: &[Target],
-        _below_wire_values: &[Target],
-    ) -> Vec<Target> {
-        let ins: Vec<Target> = (0..RESCUE_SPONGE_WIDTH)
+        local_constant_values: &[Target<C::ScalarField>],
+        local_wire_values: &[Target<C::ScalarField>],
+        right_wire_values: &[Target<C::ScalarField>],
+        _below_wire_values: &[Target<C::ScalarField>],
+    ) -> Vec<Target<C::ScalarField>> {
+        let ins: Vec<Target<C::ScalarField>> = (0..RESCUE_SPONGE_WIDTH)
             .map(|i| local_wire_values[Self::wire_acc(i)])
             .collect();
 
-        let exps: Vec<Target> = ins
+        let exps: Vec<Target<C::ScalarField>> = ins
             .into_iter()
             .map(|n| builder.exp_constant_usize(n, 5))
             .collect();
 
-        let outs: Vec<Target> = (0..RESCUE_SPONGE_WIDTH)
+        let outs: Vec<Target<C::ScalarField>> = (0..RESCUE_SPONGE_WIDTH)
             .map(|i| right_wire_values[Self::wire_acc(i)])
             .collect();
 
@@ -93,7 +93,7 @@ impl<C: HaloCurve> Gate<C> for RescueStepBGate<C> {
 }
 
 impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for RescueStepBGate<C> {
-    fn dependencies(&self) -> Vec<Target> {
+    fn dependencies(&self) -> Vec<Target<C::ScalarField>> {
         (0..RESCUE_SPONGE_WIDTH)
             .map(|i| {
                 Target::Wire(Wire {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -4,12 +4,12 @@ use rand_chacha::ChaCha8Rng;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
-pub struct TargetPartitions {
-    partitions: Vec<Vec<Target>>,
-    indices: HashMap<Target, usize>,
+pub struct TargetPartitions<F: Field> {
+    partitions: Vec<Vec<Target<F>>>,
+    indices: HashMap<Target<F>, usize>,
 }
 
-impl TargetPartitions {
+impl<F: Field> TargetPartitions<F> {
     pub fn new() -> Self {
         Self {
             partitions: Vec::new(),
@@ -17,12 +17,12 @@ impl TargetPartitions {
         }
     }
 
-    pub fn get_partition(&self, target: Target) -> &[Target] {
+    pub fn get_partition(&self, target: Target<F>) -> &[Target<F>] {
         &self.partitions[self.indices[&target]]
     }
 
     /// Add a new partition with a single member.
-    pub fn add_partition(&mut self, target: Target) {
+    pub fn add_partition(&mut self, target: Target<F>) {
         let index = self.partitions.len();
         self.partitions.push(vec![target]);
         self.indices.insert(target, index);
@@ -30,7 +30,7 @@ impl TargetPartitions {
 
     /// Merge the two partitions containing the two given targets. Does nothing if the targets are
     /// already members of the same partition.
-    pub fn merge(&mut self, a: Target, b: Target) {
+    pub fn merge(&mut self, a: Target<F>, b: Target<F>) {
         let a_index = self.indices[&a];
         let b_index = self.indices[&b];
         if a_index != b_index {

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -32,7 +32,7 @@ pub struct Circuit<C: HaloCurve> {
     pub security_bits: usize,
     pub num_public_inputs: usize,
     pub gate_constants: Vec<Vec<C::ScalarField>>,
-    pub routing_target_partitions: TargetPartitions,
+    pub routing_target_partitions: TargetPartitions<C::ScalarField>,
     pub generators: Vec<Box<dyn WitnessGenerator<C::ScalarField>>>,
     /// A generator of `subgroup_n`.
     pub subgroup_generator_n: C::ScalarField,
@@ -488,7 +488,8 @@ impl<C: HaloCurve> Circuit<C> {
         let start = Instant::now();
 
         // Index generator indices by their dependencies.
-        let mut generator_indices_by_deps: HashMap<Target, Vec<usize>> = HashMap::new();
+        let mut generator_indices_by_deps: HashMap<Target<C::ScalarField>, Vec<usize>> =
+            HashMap::new();
         for (i, generator) in self.generators.iter().enumerate() {
             for dep in generator.dependencies() {
                 generator_indices_by_deps
@@ -520,7 +521,7 @@ impl<C: HaloCurve> Circuit<C> {
         //   newly-populated targets.
         // - Generate a new set of pending generators based on the newly-populated targets.
         while !pending_generator_indices.is_empty() {
-            let mut populated_targets: Vec<Target> = Vec::new();
+            let mut populated_targets: Vec<Target<C::ScalarField>> = Vec::new();
 
             for &generator_idx in &pending_generator_indices {
                 let generator: &dyn WitnessGenerator<C::ScalarField> =
@@ -584,7 +585,7 @@ impl<C: HaloCurve> Circuit<C> {
     fn generate_copies(
         &self,
         witness: &PartialWitness<C::ScalarField>,
-        targets: &[Target],
+        targets: &[Target<C::ScalarField>],
     ) -> PartialWitness<C::ScalarField> {
         let mut result = PartialWitness::new();
 

--- a/src/plonk_challenger.rs
+++ b/src/plonk_challenger.rs
@@ -257,7 +257,8 @@ mod tests {
 
         let mut builder = CircuitBuilder::<C>::new(128);
         let mut recursive_challenger = RecursiveChallenger::new(&mut builder);
-        let mut recursive_outputs_per_round: Vec<Vec<Target<C::BaseField>>> = Vec::new();
+        let mut recursive_outputs_per_round: Vec<Vec<Target<<C as Curve>::ScalarField>>> =
+            Vec::new();
         for (r, inputs) in inputs_per_round.iter().enumerate() {
             recursive_challenger.observe_elements(&builder.constant_wires(inputs));
             recursive_outputs_per_round.push(

--- a/src/plonk_proof.rs
+++ b/src/plonk_proof.rs
@@ -209,9 +209,7 @@ pub struct ProofTarget<C: Curve, InnerC: Curve<BaseField = C::ScalarField>> {
     pub schnorr_proof: SchnorrProofTarget<InnerC>,
 }
 
-impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField, ScalarField = C::BaseField>>
-    ProofTarget<C, InnerC>
-{
+impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>> ProofTarget<C, InnerC> {
     /// `log_2(d)`, where `d` is the degree of the proof being verified.
     #[allow(dead_code)]
     fn degree_pow(&self) -> usize {
@@ -263,11 +261,11 @@ impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField, ScalarField = C
         witness.set_point_target(self.schnorr_proof.r, values.schnorr_proof.r);
         witness.set_target(
             self.schnorr_proof.z1.convert(),
-            C::try_convert_b2s(values.schnorr_proof.z1)?,
+            values.schnorr_proof.z1.try_convert()?,
         );
         witness.set_target(
             self.schnorr_proof.z2.convert(),
-            C::try_convert_b2s(values.schnorr_proof.z2)?,
+            values.schnorr_proof.z2.try_convert()?,
         );
 
         Ok(())
@@ -338,35 +336,35 @@ impl<C: Curve> OpeningSetTarget<C> {
         .concat()
     }
 
-    pub fn populate_witness(
+    pub fn populate_witness<F: Field>(
         &self,
         witness: &mut PartialWitness<C::ScalarField>,
-        values: &OpeningSet<C::BaseField>,
+        values: &OpeningSet<F>,
     ) -> Result<()> {
         // TODO: We temporarily assume that each opened value fits in both fields.
         witness.set_targets(
             &self.o_constants,
-            &C::try_convert_b2s_slice(&values.o_constants)?,
+            &Field::try_convert_all(&values.o_constants)?,
         );
         witness.set_targets(
             &Target::convert_slice(&self.o_plonk_sigmas),
-            &C::try_convert_b2s_slice(&values.o_plonk_sigmas)?,
+            &Field::try_convert_all(&values.o_plonk_sigmas)?,
         );
         witness.set_targets(
             &Target::convert_slice(&self.o_wires),
-            &C::try_convert_b2s_slice(&values.o_wires)?,
+            &Field::try_convert_all(&values.o_wires)?,
         );
         witness.set_target(
             self.o_plonk_z.convert(),
-            C::try_convert_b2s(values.o_plonk_z)?,
+            Field::try_convert(&values.o_plonk_z)?,
         );
         witness.set_targets(
             &Target::convert_slice(&self.o_plonk_t),
-            &C::try_convert_b2s_slice(&values.o_plonk_t)?,
+            &Field::try_convert_all(&values.o_plonk_t)?,
         );
         witness.set_targets(
             &Target::convert_slice(&self.o_old_proofs),
-            &C::try_convert_b2s_slice(&values.o_old_proofs)?,
+            &Field::try_convert_all(&values.o_old_proofs)?,
         );
         Ok(())
     }

--- a/src/plonk_proof.rs
+++ b/src/plonk_proof.rs
@@ -11,10 +11,10 @@ pub struct SchnorrProof<C: HaloCurve> {
     pub z2: C::ScalarField,
 }
 
-pub struct SchnorrProofTarget {
-    pub r: AffinePointTarget,
-    pub z1: Target,
-    pub z2: Target,
+pub struct SchnorrProofTarget<C: Curve> {
+    pub r: AffinePointTarget<C>,
+    pub z1: Target<C::ScalarField>,
+    pub z2: Target<C::ScalarField>,
 }
 
 #[derive(Debug, Clone)]
@@ -160,13 +160,13 @@ impl<C: HaloCurve> OldProof<C> {
 
 #[derive(Debug, Clone)]
 /// The `Target` version of `OldProof`.
-pub struct OldProofTarget {
-    pub halo_g: AffinePointTarget,
-    pub halo_us: Vec<Target>,
+pub struct OldProofTarget<C: Curve> {
+    pub halo_g: AffinePointTarget<C>,
+    pub halo_us: Vec<Target<C::ScalarField>>,
 }
 
-impl OldProofTarget {
-    pub fn populate_witness<C: HaloCurve>(
+impl<C: HaloCurve> OldProofTarget<C> {
+    pub fn populate_witness(
         &self,
         witness: &mut PartialWitness<C::BaseField>,
         values: &OldProof<C>,
@@ -174,7 +174,7 @@ impl OldProofTarget {
         witness.set_point_target(self.halo_g, values.halo_g);
         debug_assert_eq!(self.halo_us.len(), values.halo_us.len());
         witness.set_targets(
-            &self.halo_us,
+            &Target::convert_slice(&self.halo_us),
             &C::ScalarField::try_convert_all(&values.halo_us)?,
         );
 
@@ -182,41 +182,41 @@ impl OldProofTarget {
     }
 }
 
-pub struct ProofTarget {
+pub struct ProofTarget<C: Curve> {
     /// A commitment to each wire polynomial.
-    pub c_wires: Vec<AffinePointTarget>,
+    pub c_wires: Vec<AffinePointTarget<C>>,
     /// A commitment to Z, in the context of the permutation argument.
-    pub c_plonk_z: AffinePointTarget,
+    pub c_plonk_z: AffinePointTarget<C>,
     /// A commitment to the quotient polynomial.
-    pub c_plonk_t: Vec<AffinePointTarget>,
+    pub c_plonk_t: Vec<AffinePointTarget<C>>,
 
     /// The opening of each polynomial at each `PublicInputGate` index.
-    pub o_public_inputs: Option<Vec<OpeningSetTarget>>,
+    pub o_public_inputs: Option<Vec<OpeningSetTarget<C>>>,
     /// The opening of each polynomial at `zeta`.
-    pub o_local: OpeningSetTarget,
+    pub o_local: OpeningSetTarget<C>,
     /// The opening of each polynomial at `g * zeta`.
-    pub o_right: OpeningSetTarget,
+    pub o_right: OpeningSetTarget<C>,
     /// The opening of each polynomial at `g^65 * zeta`.
-    pub o_below: OpeningSetTarget,
+    pub o_below: OpeningSetTarget<C>,
 
     /// L_i in the Halo reduction.
-    pub halo_l_i: Vec<AffinePointTarget>,
+    pub halo_l_i: Vec<AffinePointTarget<C>>,
     /// R_i in the Halo reduction.
-    pub halo_r_i: Vec<AffinePointTarget>,
+    pub halo_r_i: Vec<AffinePointTarget<C>>,
     /// The purported value of G, i.e. <s, G>, in the context of Halo.
-    pub halo_g: AffinePointTarget,
+    pub halo_g: AffinePointTarget<C>,
     /// The data used in the final Schnorr protocol of the Halo opening proof.
-    pub schnorr_proof: SchnorrProofTarget,
+    pub schnorr_proof: SchnorrProofTarget<C>,
 }
 
-impl ProofTarget {
+impl<C: HaloCurve> ProofTarget<C> {
     /// `log_2(d)`, where `d` is the degree of the proof being verified.
     #[allow(dead_code)]
     fn degree_pow(&self) -> usize {
         self.halo_l_i.len()
     }
 
-    pub fn all_opening_sets(&self) -> Vec<OpeningSetTarget> {
+    pub fn all_opening_sets(&self) -> Vec<OpeningSetTarget<C>> {
         [
             if let Some(pis) = &self.o_public_inputs {
                 pis.as_slice()
@@ -232,8 +232,8 @@ impl ProofTarget {
         .concat()
     }
 
-    pub fn all_opening_targets(&self) -> Vec<Target> {
-        let targets_2d: Vec<Vec<Target>> = self
+    pub fn all_opening_targets(&self) -> Vec<Target<C::ScalarField>> {
+        let targets_2d: Vec<Vec<Target<C::ScalarField>>> = self
             .all_opening_sets()
             .into_iter()
             .map(|set| set.to_vec())
@@ -241,7 +241,7 @@ impl ProofTarget {
         targets_2d.concat()
     }
 
-    pub fn populate_witness<C: HaloCurve>(
+    pub fn populate_witness(
         &self,
         witness: &mut PartialWitness<C::BaseField>,
         values: Proof<C>,
@@ -260,11 +260,11 @@ impl ProofTarget {
 
         witness.set_point_target(self.schnorr_proof.r, values.schnorr_proof.r);
         witness.set_target(
-            self.schnorr_proof.z1,
+            self.schnorr_proof.z1.convert(),
             C::ScalarField::try_convert(&values.schnorr_proof.z1)?,
         );
         witness.set_target(
-            self.schnorr_proof.z2,
+            self.schnorr_proof.z2.convert(),
             C::ScalarField::try_convert(&values.schnorr_proof.z2)?,
         );
 
@@ -308,23 +308,23 @@ impl<F: Field> OpeningSet<F> {
 
 /// The opening of each Plonk polynomial at a particular point.
 #[derive(Clone)]
-pub struct OpeningSetTarget {
+pub struct OpeningSetTarget<C: Curve> {
     /// The purported opening of each constant polynomial.
-    pub o_constants: Vec<Target>,
+    pub o_constants: Vec<Target<C::ScalarField>>,
     /// The purported opening of each S_sigma polynomial in the context of Plonk's permutation argument.
-    pub o_plonk_sigmas: Vec<Target>,
+    pub o_plonk_sigmas: Vec<Target<C::ScalarField>>,
     /// The purported opening of each wire polynomial.
-    pub o_wires: Vec<Target>,
+    pub o_wires: Vec<Target<C::ScalarField>>,
     /// The purported opening of `Z`.
-    pub o_plonk_z: Target,
+    pub o_plonk_z: Target<C::ScalarField>,
     /// The purported opening of `t`.
-    pub o_plonk_t: Vec<Target>,
+    pub o_plonk_t: Vec<Target<C::ScalarField>>,
     /// The purported opening of some old proofs `halo_g` polynomials.
-    pub o_old_proofs: Vec<Target>,
+    pub o_old_proofs: Vec<Target<C::ScalarField>>,
 }
 
-impl OpeningSetTarget {
-    pub fn to_vec(&self) -> Vec<Target> {
+impl<C: Curve> OpeningSetTarget<C> {
+    pub fn to_vec(&self) -> Vec<Target<C::ScalarField>> {
         [
             self.o_constants.as_slice(),
             self.o_plonk_sigmas.as_slice(),
@@ -336,32 +336,35 @@ impl OpeningSetTarget {
         .concat()
     }
 
-    pub fn populate_witness<InnerBF: Field, InnerSF: Field>(
+    pub fn populate_witness(
         &self,
-        witness: &mut PartialWitness<InnerBF>,
-        values: &OpeningSet<InnerSF>,
+        witness: &mut PartialWitness<C::BaseField>,
+        values: &OpeningSet<C::ScalarField>,
     ) -> Result<()> {
         // TODO: We temporarily assume that each opened value fits in both fields.
         witness.set_targets(
-            &self.o_constants,
-            &InnerSF::try_convert_all::<InnerBF>(&values.o_constants)?,
+            &Target::convert_slice(&self.o_constants),
+            &C::try_convert_s2b_slice(&values.o_constants)?,
         );
         witness.set_targets(
-            &self.o_plonk_sigmas,
-            &InnerSF::try_convert_all::<InnerBF>(&values.o_plonk_sigmas)?,
+            &Target::convert_slice(&self.o_plonk_sigmas),
+            &C::try_convert_s2b_slice(&values.o_plonk_sigmas)?,
         );
         witness.set_targets(
-            &self.o_wires,
-            &InnerSF::try_convert_all::<InnerBF>(&values.o_wires)?,
+            &Target::convert_slice(&self.o_wires),
+            &C::try_convert_s2b_slice(&values.o_wires)?,
         );
-        witness.set_target(self.o_plonk_z, values.o_plonk_z.try_convert::<InnerBF>()?);
-        witness.set_targets(
-            &self.o_plonk_t,
-            &InnerSF::try_convert_all::<InnerBF>(&values.o_plonk_t)?,
+        witness.set_target(
+            self.o_plonk_z.convert(),
+            C::try_convert_s2b(values.o_plonk_z)?,
         );
         witness.set_targets(
-            &self.o_old_proofs,
-            &InnerSF::try_convert_all::<InnerBF>(&values.o_old_proofs)?,
+            &Target::convert_slice(&self.o_plonk_t),
+            &C::try_convert_s2b_slice(&values.o_plonk_t)?,
+        );
+        witness.set_targets(
+            &Target::convert_slice(&self.o_old_proofs),
+            &C::try_convert_s2b_slice(&values.o_old_proofs)?,
         );
         Ok(())
     }

--- a/src/plonk_recursion.rs
+++ b/src/plonk_recursion.rs
@@ -40,7 +40,7 @@ fn num_public_input_gates(num_public_inputs: usize) -> usize {
 
 pub fn recursive_verification_circuit<
     C: HaloCurve,
-    InnerC: HaloCurve<BaseField = C::ScalarField, ScalarField = C::BaseField>,
+    InnerC: HaloCurve<BaseField = C::ScalarField>,
 >(
     degree_pow: usize,
     security_bits: usize,
@@ -220,10 +220,7 @@ pub fn recursive_verification_circuit<
 }
 
 /// Verify all IPAs in the given proof, and return IPA challenges.
-fn verify_all_ipas<
-    C: HaloCurve,
-    InnerC: HaloCurve<BaseField = C::ScalarField, ScalarField = C::BaseField>,
->(
+fn verify_all_ipas<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>>(
     builder: &mut CircuitBuilder<C>,
     proof: &ProofTarget<C, InnerC>,
     zeta: Target<C::ScalarField>,

--- a/src/plonk_recursion.rs
+++ b/src/plonk_recursion.rs
@@ -6,6 +6,7 @@ use crate::util::ceil_div_usize;
 use crate::{get_subgroup_shift, hash_usize_to_curve, AffinePointTarget, Circuit, CircuitBuilder, CurveMulEndoResult, CurveMulOp, Field, HaloCurve, OpeningSetTarget, ProofTarget, PublicInput, SchnorrProofTarget, Target, GRID_WIDTH, NUM_CONSTANTS, NUM_ROUTED_WIRES, NUM_WIRES, QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER};
 
 /// Wraps a `Circuit` for recursive verification with inputs for the proof data.
+/// The circuit is over the field `C::ScalarField` and verifies a proof performed over the curve `InnerC`.
 pub struct RecursiveCircuit<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>> {
     pub circuit: Circuit<C>,
     pub public_inputs: RecursionPublicInputs<C::ScalarField>,

--- a/src/plonk_util.rs
+++ b/src/plonk_util.rs
@@ -35,9 +35,9 @@ pub fn reduce_with_powers<F: Field>(terms: &[F], alpha: F) -> F {
 /// Computes a sum of terms weighted by powers of alpha.
 pub(crate) fn reduce_with_powers_recursive<C: HaloCurve>(
     builder: &mut CircuitBuilder<C>,
-    terms: &[Target],
-    alpha: Target,
-) -> Target {
+    terms: &[Target<C::ScalarField>],
+    alpha: Target<C::ScalarField>,
+) -> Target<C::ScalarField> {
     let mut sum = builder.zero_wire();
     for &term in terms.iter().rev() {
         sum = builder.mul_add(sum, alpha, term);
@@ -137,9 +137,9 @@ pub fn powers<F: Field>(x: F, n: usize) -> Vec<F> {
 /// Compute `[x^0, x^1, ..., x^(n - 1)]`.
 pub(crate) fn powers_recursive<C: HaloCurve>(
     builder: &mut CircuitBuilder<C>,
-    x: Target,
+    x: Target<C::ScalarField>,
     n: usize,
-) -> Vec<Target> {
+) -> Vec<Target<C::ScalarField>> {
     let mut powers = Vec::new();
     let mut current = builder.one_wire();
     for i in 0..n {

--- a/src/target.rs
+++ b/src/target.rs
@@ -26,7 +26,7 @@ impl Wire {
     }
 }
 
-/// A routing target.
+/// A routing target over a field `F`.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Target<F: Field> {
     VirtualTarget(VirtualTarget),

--- a/src/target.rs
+++ b/src/target.rs
@@ -59,7 +59,7 @@ pub struct BoundedTarget<F: Field> {
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct PublicInput<F: Field> {
     pub index: usize,
-    _field: PhantomData<F>,
+    pub _field: PhantomData<F>,
 }
 
 /// See `PublicInputGate` for an explanation of how we make public inputs routable.


### PR DESCRIPTION
Added field and curve types to target structs, e.g., `Target` is now `Target<F>` where `F: Field`.
This allows for compile-time checks that the code is handling values in the correct field.