### PR TITLE
Separate module for arithmetic tests

### DIFF
--- a/src/field/bls12_377_base.rs
+++ b/src/field/bls12_377_base.rs
@@ -284,6 +284,7 @@ mod tests {
     use crate::Bls12377Base;
     use crate::conversions::u64_slice_to_biguint;
     use crate::{test_square_root, test_arithmetic};
+    use crate::Field;
 
     #[test]
     fn bls12base_to_and_from_canonical() {
@@ -383,6 +384,6 @@ mod tests {
         assert_eq!(Bls12377Base::FIVE.kth_root_u32(11).exp_u32(11), Bls12377Base::FIVE);
     }
 
-    test_square_root!(Bls12377Base);
-    test_arithmetic!(Bls12377Base);
+    test_square_root!(crate::Bls12377Base);
+    test_arithmetic!(crate::Bls12377Base);
 }

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -303,6 +303,7 @@ impl Debug for TweedledeeBase {
 mod tests {
     use crate::{test_square_root, test_arithmetic};
     use crate::TweedledeeBase;
+    use crate::Field;
 
     #[test]
     fn primitive_root_order() {
@@ -325,6 +326,6 @@ mod tests {
         assert_eq!(TweedledeeBase::is_valid_canonical_u64(&limbs), false);
     }
 
-    test_square_root!(TweedledeeBase);
-    test_arithmetic!(TweedledeeBase);
+    test_square_root!(crate::TweedledeeBase);
+    test_arithmetic!(crate::TweedledeeBase);
 }

--- a/src/field/tweedledum_base.rs
+++ b/src/field/tweedledum_base.rs
@@ -304,6 +304,7 @@ impl Debug for TweedledumBase {
 mod tests {
     use crate::{test_square_root, test_arithmetic};
     use crate::TweedledumBase;
+    use crate::Field;
 
     #[test]
     fn primitive_root_order() {
@@ -314,6 +315,6 @@ mod tests {
         }
     }
 
-    test_square_root!(TweedledumBase);
-    test_arithmetic!(TweedledumBase);
+    test_square_root!(crate::TweedledumBase);
+    test_arithmetic!(crate::TweedledumBase);
 }


### PR DESCRIPTION
There were a couple things causing compiler errors --

- The macro calls were using non-qualified names, as in `test_arithmetic!(TweedledumBase)`, but `TweedledumBase` is no longer in scope in the context of the new submodule. I switched to qualified names, as in `test_arithmetic!(crate::TweedledumBase)`.
- I needed to add back the `Field` imports in modules like `bls12_377_base::test`. Previously it was pulled in by `test_arithmetic!`, but not anymore since the macro imports it into a submodule.