### PR TITLE
Issue 70: Fast modular squaring

### DIFF
--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -647,7 +647,7 @@ macro_rules! test_arithmetic {
                 let modulus = field_modulus::<$field>();
                 field_tests::run_unaryop_test_cases(
                     &modulus, WORD_BITS,
-                    |x| <$field>::mul(x, x),
+                    |x| <$field>::square(&x),
                     |x| &x * &x % &modulus)
             }
 

--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -3,6 +3,7 @@ pub use bls12_377_scalar::*;
 pub use field::*;
 pub use tweedledee_base::*;
 pub use tweedledum_base::*;
+pub use monty::*;
 
 mod bls12_377_base;
 mod bls12_377_scalar;
@@ -10,3 +11,4 @@ mod bls12_377_scalar;
 mod field;
 mod tweedledee_base;
 mod tweedledum_base;
+mod monty;

--- a/src/field/monty.rs
+++ b/src/field/monty.rs
@@ -56,7 +56,6 @@ pub trait MontyRepr {
     }
 
     fn monty_neg(limbs: [u64; 4]) -> [u64; 4] {
-        // FIXME: Should have a MontyRepr::ZERO or 'is_zero()'
         if limbs == Self::ZERO {
             Self::ZERO
         } else {
@@ -151,6 +150,7 @@ pub trait MontyRepr {
             c[4 - 1] = t;
             hi = cy as u64;
         }
+        // NB: This is only true for the Tweedle* curves.
         debug_assert_eq!(hi, 0u64);
         // Final conditional subtraction.
         if cmp(c, Self::ORDER) != Less {
@@ -162,8 +162,6 @@ pub trait MontyRepr {
     fn monty_inverse(limbs: [u64; 4]) -> [u64; 4] {
         // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 =
         // x^-1 R.
-        // TODO: There are faster ways to do this (for example, see McIvor,
-        // McLoone and McCanny (2004)).
         let self_r_inv = nonzero_multiplicative_inverse(limbs, Self::ORDER);
         Self::monty_multiply(self_r_inv, Self::R3)
     }

--- a/src/field/monty.rs
+++ b/src/field/monty.rs
@@ -1,0 +1,180 @@
+use std::cmp::Ordering::Less;
+use unroll::unroll_for_loops;
+
+use crate::{add_no_overflow, sub, cmp, mul2, nonzero_multiplicative_inverse};
+
+// TODO: These low-level functions should be collected together in their own
+// module.
+#[inline]
+fn mul_add_cy_in(a: u64, b: u64, c: u64, cy_in: u64) -> (u64, u64) {
+    let t = (a as u128) * (b as u128) + (c as u128) + (cy_in as u128);
+    ((t >> 64) as u64, t as u64)
+}
+
+#[inline]
+fn mul_add(a: u64, b: u64, c: u64) -> (u64, u64) {
+    let t = (a as u128) * (b as u128) + (c as u128);
+    ((t >> 64) as u64, t as u64)
+}
+
+
+pub trait MontyRepr {
+    /// The order of the field
+    const ORDER: [u64; 4];
+    /// Twice the order of the field
+    const ORDER_X2: [u64; 4];
+    /// R in the context of the Montgomery reduction, i.e. 2^256 % |F|.
+    const R: [u64; 4];
+    /// R^2 in the context of the Montgomery reduction, i.e. 2^(256*2) % |F|.
+    const R2: [u64; 4];
+    /// R^3 in the context of the Montgomery reduction, i.e. 2^(256*3) % |F|.
+    const R3: [u64; 4];
+    /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
+    const MU: u64;
+
+    const ZERO: [u64; 4] = [0u64; 4];
+    const ONE: [u64; 4] = Self::R;
+
+    fn monty_add(lhs: [u64; 4], rhs: [u64; 4]) -> [u64; 4] {
+        // First we do a widening addition, then we reduce if necessary.
+        let sum = add_no_overflow(lhs, rhs);
+        if cmp(sum, Self::ORDER) == Less {
+            sum
+        } else {
+            sub(sum, Self::ORDER)
+        }
+    }
+
+    fn monty_sub(lhs: [u64; 4], rhs: [u64; 4]) -> [u64; 4] {
+        if cmp(lhs, rhs) == Less {
+            // Underflow occurs, so we compute the difference as `self + (-rhs)`.
+            add_no_overflow(lhs, Self::monty_neg(rhs))
+        } else {
+            // No underflow, so it's faster to subtract directly.
+            sub(lhs, rhs)
+        }
+    }
+
+    fn monty_neg(limbs: [u64; 4]) -> [u64; 4] {
+        // FIXME: Should have a MontyRepr::ZERO or 'is_zero()'
+        if limbs == Self::ZERO {
+            Self::ZERO
+        } else {
+            sub(Self::ORDER, limbs)
+        }
+    }
+
+    #[unroll_for_loops]
+    fn monty_multiply(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+        // Interleaved Montgomery multiplication, as described in Algorithm 2 of
+        // https://eprint.iacr.org/2017/1057.pdf
+
+        // Note that in the loop below, to avoid explicitly shifting c, we will treat i as the least
+        // significant digit and wrap around.
+        let mut c = [0u64; 5];
+
+        for i in 0..4 {
+            // Add a[i] b to c.
+            let mut carry = 0;
+            for j in 0..4 {
+                let result = c[(i + j) % 5] as u128 + a[i] as u128 * b[j] as u128 + carry as u128;
+                c[(i + j) % 5] = result as u64;
+                carry = (result >> 64) as u64;
+            }
+            c[(i + 4) % 5] += carry;
+
+            // q = u c mod r = u c[0] mod r.
+            let q = Self::MU.wrapping_mul(c[i]);
+
+            // C += N q
+            carry = 0;
+            for j in 0..4 {
+                let result =
+                    c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
+                c[(i + j) % 5] = result as u64;
+                carry = (result >> 64) as u64;
+            }
+            c[(i + 4) % 5] += carry;
+
+            debug_assert_eq!(c[i], 0);
+        }
+
+        let mut result = [c[4], c[0], c[1], c[2]];
+        // Final conditional subtraction.
+        if cmp(result, Self::ORDER) != Less {
+            result = sub(result, Self::ORDER);
+        }
+        result
+    }
+
+    #[unroll_for_loops]
+    fn monty_square(a: [u64; 4]) -> [u64; 4] {
+        let mut c = [0u64; 4];
+        let mut hi = 0u64;
+
+        for i in 0 .. 4 {
+            // u holds the off-diagonal part of the square calculation. Only the
+            // first N - i elements are used.
+            let mut u = [0u64; 4];
+            let mut hi_in = 0u64;
+            for j in i+1 .. 4 {
+                let (hi_out, lo) = mul_add(a[j], a[i], hi_in);
+                u[j - (i+1)] = lo;
+                hi_in = hi_out;
+            }
+            u[4 - (i+1)] = hi_in;
+            u = mul2(u);
+            let (mut hi_in, lo) = mul_add(a[i], a[i], c[i]);
+            c[i] = lo;
+            for j in i+1 .. 4 {
+                // c[j] = c[j] + u[j] + hi_in
+                let (t, cy1) = c[j].overflowing_add(hi_in);
+                let (t, cy2) = u[j - (i+1)].overflowing_add(t);
+                c[j] = t;
+                hi_in = (cy1 as u64) + (cy2 as u64);
+            }
+
+            let (t, cy1) = hi.overflowing_add(hi_in);
+            let (t, cy2) = u[4 - (i+1)].overflowing_add(t);
+            hi = t;
+            debug_assert_eq!(cy1 | cy2, false);
+
+            let m = c[0].wrapping_mul(Self::MU);
+            let (mut hi_in, lo) = mul_add(Self::ORDER[0], m, c[0]);
+            debug_assert_eq!(lo, 0u64);
+            for j in 1 .. 4 {
+                let (hi_out, lo) = mul_add_cy_in(Self::ORDER[j], m, c[j], hi_in);
+                c[j - 1] = lo;
+                hi_in = hi_out;
+            }
+            let (t, cy) = hi.overflowing_add(hi_in);
+            c[4 - 1] = t;
+            hi = cy as u64;
+        }
+        debug_assert_eq!(hi, 0u64);
+        // Final conditional subtraction.
+        if cmp(c, Self::ORDER) != Less {
+            c = sub(c, Self::ORDER);
+        }
+        c
+    }
+
+    fn monty_inverse(limbs: [u64; 4]) -> [u64; 4] {
+        // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 =
+        // x^-1 R.
+        // TODO: There are faster ways to do this (for example, see McIvor,
+        // McLoone and McCanny (2004)).
+        let self_r_inv = nonzero_multiplicative_inverse(limbs, Self::ORDER);
+        Self::monty_multiply(self_r_inv, Self::R3)
+    }
+
+    fn from_monty(c: [u64; 4]) -> [u64; 4] {
+        // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
+        Self::monty_multiply(c, Self::R2)
+    }
+
+    fn to_monty(limbs: [u64; 4]) -> [u64; 4] {
+        // Let x * R = limbs. We compute M(x * R, 1) = x * R * R^-1 = x.
+        Self::monty_multiply(limbs, [1, 0, 0, 0])
+    }
+}

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -6,10 +6,154 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 use unroll::unroll_for_loops;
 
 use crate::nonzero_multiplicative_inverse;
-use crate::{add_no_overflow, cmp, field_to_biguint, rand_range, rand_range_from_rng, sub, Field};
+use crate::{add_no_overflow, mul2, cmp, field_to_biguint, rand_range, rand_range_from_rng, sub, Field};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
+
+// TODO: These low-level functions should be collected together in their own
+// module.
+#[inline]
+fn mul_add_cy_in(a: u64, b: u64, c: u64, cy_in: u64) -> (u64, u64) {
+    let t = (a as u128) * (b as u128) + (c as u128) + (cy_in as u128);
+    ((t >> 64) as u64, t as u64)
+}
+
+#[inline]
+fn mul_add(a: u64, b: u64, c: u64) -> (u64, u64) {
+    let t = (a as u128) * (b as u128) + (c as u128);
+    ((t >> 64) as u64, t as u64)
+}
+
+
+pub trait MontyRepr {
+    /// The order of the field
+    const ORDER: [u64; 4];
+    /// Twice the order of the field
+    const ORDER_X2: [u64; 4];
+    /// R in the context of the Montgomery reduction, i.e. 2^256 % |F|.
+    const R: [u64; 4];
+    /// R^2 in the context of the Montgomery reduction, i.e. 2^(256*2) % |F|.
+    const R2: [u64; 4];
+    /// R^3 in the context of the Montgomery reduction, i.e. 2^(256*3) % |F|.
+    const R3: [u64; 4];
+    /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
+    const MU: u64;
+
+    #[unroll_for_loops]
+    fn monty_multiply(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+        // Interleaved Montgomery multiplication, as described in Algorithm 2 of
+        // https://eprint.iacr.org/2017/1057.pdf
+
+        // Note that in the loop below, to avoid explicitly shifting c, we will treat i as the least
+        // significant digit and wrap around.
+        let mut c = [0u64; 5];
+
+        for i in 0..4 {
+            // Add a[i] b to c.
+            let mut carry = 0;
+            for j in 0..4 {
+                let result = c[(i + j) % 5] as u128 + a[i] as u128 * b[j] as u128 + carry as u128;
+                c[(i + j) % 5] = result as u64;
+                carry = (result >> 64) as u64;
+            }
+            c[(i + 4) % 5] += carry;
+
+            // q = u c mod r = u c[0] mod r.
+            let q = Self::MU.wrapping_mul(c[i]);
+
+            // C += N q
+            carry = 0;
+            for j in 0..4 {
+                let result =
+                    c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
+                c[(i + j) % 5] = result as u64;
+                carry = (result >> 64) as u64;
+            }
+            c[(i + 4) % 5] += carry;
+
+            debug_assert_eq!(c[i], 0);
+        }
+
+        let mut result = [c[4], c[0], c[1], c[2]];
+        // Final conditional subtraction.
+        if cmp(result, Self::ORDER) != Less {
+            result = sub(result, Self::ORDER);
+        }
+        result
+    }
+
+    #[unroll_for_loops]
+    fn monty_square(a: [u64; 4]) -> [u64; 4] {
+        let mut c = [0u64; 4];
+        let mut hi = 0u64;
+
+        for i in 0 .. 4 {
+            // u holds the off-diagonal part of the square calculation. Only the
+            // first N - i elements are used.
+            let mut u = [0u64; 4];
+            let mut hi_in = 0u64;
+            for j in i+1 .. 4 {
+                let (hi_out, lo) = mul_add(a[j], a[i], hi_in);
+                u[j - (i+1)] = lo;
+                hi_in = hi_out;
+            }
+            u[4 - (i+1)] = hi_in;
+            u = mul2(u);
+            let (mut hi_in, lo) = mul_add(a[i], a[i], c[i]);
+            c[i] = lo;
+            for j in i+1 .. 4 {
+                // c[j] = c[j] + u[j] + hi_in
+                let (t, cy1) = c[j].overflowing_add(hi_in);
+                let (t, cy2) = u[j - (i+1)].overflowing_add(t);
+                c[j] = t;
+                hi_in = (cy1 as u64) + (cy2 as u64);
+            }
+
+            let (t, cy1) = hi.overflowing_add(hi_in);
+            let (t, cy2) = u[4 - (i+1)].overflowing_add(t);
+            hi = t;
+            debug_assert_eq!(cy1 | cy2, false);
+
+            let m = c[0].wrapping_mul(Self::MU);
+            let (mut hi_in, lo) = mul_add(Self::ORDER[0], m, c[0]);
+            debug_assert_eq!(lo, 0u64);
+            for j in 1 .. 4 {
+                let (hi_out, lo) = mul_add_cy_in(Self::ORDER[j], m, c[j], hi_in);
+                c[j - 1] = lo;
+                hi_in = hi_out;
+            }
+            let (t, cy) = hi.overflowing_add(hi_in);
+            c[4 - 1] = t;
+            hi = cy as u64;
+        }
+        debug_assert_eq!(hi, 0u64);
+        // Final conditional subtraction.
+        if cmp(c, Self::ORDER) != Less {
+            c = sub(c, Self::ORDER);
+        }
+        c
+    }
+
+    fn monty_inverse(limbs: [u64; 4]) -> [u64; 4] {
+        // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 =
+        // x^-1 R.
+        // TODO: There are faster ways to do this (for example, see McIvor,
+        // McLoone and McCanny (2004)).
+        let self_r_inv = nonzero_multiplicative_inverse(limbs, Self::ORDER);
+        Self::monty_multiply(self_r_inv, Self::R3)
+    }
+
+    fn from_monty(c: [u64; 4]) -> [u64; 4] {
+        // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
+        Self::monty_multiply(c, Self::R2)
+    }
+
+    fn to_monty(limbs: [u64; 4]) -> [u64; 4] {
+        // Let x * R = limbs. We compute M(x * R, 1) = x * R * R^-1 = x.
+        Self::monty_multiply(limbs, [1, 0, 0, 0])
+    }
+}
 
 /// An element of the Tweedledee group's base field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
@@ -18,7 +162,7 @@ pub struct TweedledeeBase {
     pub limbs: [u64; 4],
 }
 
-impl TweedledeeBase {
+impl MontyRepr for TweedledeeBase {
     /// The order of the field: 28948022309329048855892746252171976963322203655954433126947083963168578338817
     const ORDER: [u64; 4] = [
         9524180637049683969,
@@ -62,137 +206,15 @@ impl TweedledeeBase {
 
     /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
     const MU: u64 = 9524180637049683967;
+}
 
+impl TweedledeeBase {
     pub fn from_canonical(c: [u64; 4]) -> Self {
-        // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
-        Self {
-            limbs: Self::montgomery_multiply(c, Self::R2),
-        }
+        Self { limbs: Self::from_monty(c) }
     }
 
     pub fn to_canonical(&self) -> [u64; 4] {
-        // Let x * R = self. We compute M(x * R, 1) = x * R * R^-1 = x.
-        Self::montgomery_multiply(self.limbs, [1, 0, 0, 0])
-    }
-
-    #[unroll_for_loops]
-    fn montgomery_multiply(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
-        // Interleaved Montgomery multiplication, as described in Algorithm 2 of
-        // https://eprint.iacr.org/2017/1057.pdf
-
-        // Note that in the loop below, to avoid explicitly shifting c, we will treat i as the least
-        // significant digit and wrap around.
-        let mut c = [0u64; 5];
-
-        for i in 0..4 {
-            // Add a[i] b to c.
-            let mut carry = 0;
-            for j in 0..4 {
-                let result = c[(i + j) % 5] as u128 + a[i] as u128 * b[j] as u128 + carry as u128;
-                c[(i + j) % 5] = result as u64;
-                carry = (result >> 64) as u64;
-            }
-            c[(i + 4) % 5] += carry;
-
-            // q = u c mod r = u c[0] mod r.
-            let q = Self::MU.wrapping_mul(c[i]);
-
-            // C += N q
-            carry = 0;
-            for j in 0..4 {
-                let result =
-                    c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
-                c[(i + j) % 5] = result as u64;
-                carry = (result >> 64) as u64;
-            }
-            c[(i + 4) % 5] += carry;
-
-            debug_assert_eq!(c[i], 0);
-        }
-
-        let mut result = [c[4], c[0], c[1], c[2]];
-        // Final conditional subtraction.
-        if cmp(result, Self::ORDER) != Less {
-            result = sub(result, Self::ORDER);
-        }
-        result
-    }
-
-    #[inline]
-    fn mul_add_cy_in(a: u64, b: u64, c: u64, cy_in: u64) -> (u64, u64) {
-        let t = (a as u128) * (b as u128) + (c as u128) + (cy_in as u128);
-        ((t >> 64) as u64, t as u64)
-    }
-
-    #[inline]
-    fn mul_add(a: u64, b: u64, c: u64) -> (u64, u64) {
-        let t = (a as u128) * (b as u128) + (c as u128);
-        ((t >> 64) as u64, t as u64)
-    }
-
-    #[inline]
-    #[unroll_for_loops]
-    fn mul2(u: &mut [u64; 4]) {
-        let mut cy_in = 0u64;
-        for i in 0 .. 4 {
-            let v = u[i].wrapping_shl(1);
-            let cy_out = u[i].wrapping_shr(63);
-            u[i] = v + cy_in;
-            cy_in = cy_out;
-        }
-        debug_assert_eq!(cy_in, 0u64);
-    }
-
-    #[unroll_for_loops]
-    fn monty_sqr(a: [u64; 4]) -> [u64; 4] {
-        let mut c = [0u64; 4];
-        let mut hi = 0u64;
-
-        for i in 0 .. 4 {
-            // u holds the diagonal part of the square calculation. Only the first N - i
-            // elements are used.
-            let mut u = [0u64; 4];
-            let mut hi_in = 0u64;
-            for j in i+1 .. 4 {
-                let (hi_out, lo) = Self::mul_add(a[j], a[i], hi_in);
-                u[j - (i+1)] = lo;
-                hi_in = hi_out;
-            }
-            u[4 - (i+1)] = hi_in;
-            Self::mul2(&mut u);
-            let (mut hi_in, lo) = Self::mul_add(a[i], a[i], c[i]);
-            c[i] = lo;
-            for j in i+1 .. 4 {
-                // c[j] = c[j] + u[j] + hi_in
-                let (t, cy1) = c[j].overflowing_add(hi_in);
-                let (t, cy2) = u[j - (i+1)].overflowing_add(t);
-                c[j] = t;
-                hi_in = (cy1 as u64) + (cy2 as u64);
-            }
-
-            let (t, cy1) = hi.overflowing_add(hi_in);
-            let (t, cy2) = u[4 - (i+1)].overflowing_add(t);
-            hi = t;
-            debug_assert_eq!(cy1 | cy2, false);
-
-            let m = c[0].wrapping_mul(Self::MU);
-            let (mut hi_in, lo) = Self::mul_add(Self::ORDER[0], m, c[0]);
-            debug_assert_eq!(lo, 0u64);
-            for j in 1 .. 4 {
-                let (hi_out, lo) = Self::mul_add_cy_in(Self::ORDER[j], m, c[j], hi_in);
-                c[j - 1] = lo;
-                hi_in = hi_out;
-            }
-            let (t, cy) = hi.overflowing_add(hi_in);
-            c[4 - 1] = t;
-            hi = cy as u64;
-        }
-        debug_assert_eq!(hi, 0u64);
-        // Final conditional subtraction.
-        if cmp_4_4(c, Self::ORDER) != Less {
-            c = sub_4_4(c, Self::ORDER);
-        }
-        c
+        Self::to_monty(self.limbs)
     }
 }
 
@@ -231,7 +253,7 @@ impl Mul<TweedledeeBase> for TweedledeeBase {
 
     fn mul(self, rhs: Self) -> Self {
         Self {
-            limbs: Self::montgomery_multiply(self.limbs, rhs.limbs),
+            limbs: Self::monty_multiply(self.limbs, rhs.limbs),
         }
     }
 }
@@ -332,10 +354,8 @@ impl Field for TweedledeeBase {
     }
 
     fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
-        // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 = x^-1 R.
-        let self_r_inv = nonzero_multiplicative_inverse(self.limbs, Self::ORDER);
         Self {
-            limbs: Self::montgomery_multiply(self_r_inv, Self::R3),
+            limbs: Self::monty_inverse(self.limbs)
         }
     }
 
@@ -354,7 +374,7 @@ impl Field for TweedledeeBase {
     #[inline(always)]
     fn square(&self) -> Self {
         Self {
-            limbs: Self::monty_sqr(self.limbs),
+            limbs: Self::monty_square(self.limbs),
         }
     }
 }
@@ -388,6 +408,7 @@ mod tests {
     use crate::test_arithmetic;
     use crate::Field;
     use crate::TweedledeeBase;
+    use crate::MontyRepr; // This is just to access ORDER_X2.
 
     #[test]
     fn primitive_root_order() {

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn valid_canonical_vec() {
-        let small = TweedledeeBase::ONE.to_canonical_u64_vec();
+        let small = <TweedledeeBase as Field>::ONE.to_canonical_u64_vec();
         assert!(TweedledeeBase::is_valid_canonical_u64(&small));
 
         let big = TweedledeeBase::ORDER_X2.to_vec();

--- a/src/field/tweedledum_base.rs
+++ b/src/field/tweedledum_base.rs
@@ -1,15 +1,14 @@
 use rand::Rng;
+use std::cmp::Ordering;
 use std::cmp::Ordering::Less;
 use std::convert::TryInto;
 use std::ops::{Add, Div, Mul, Neg, Sub};
-
-use unroll::unroll_for_loops;
-
-use crate::nonzero_multiplicative_inverse;
-use crate::{add_no_overflow, cmp, field_to_biguint, rand_range, rand_range_from_rng, sub, Field};
-use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
+
+use crate::{cmp, field_to_biguint,
+            rand_range, rand_range_from_rng,
+            MontyRepr, Field};
 
 /// An element of the Tweedledum group's base field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
@@ -18,7 +17,7 @@ pub struct TweedledumBase {
     pub limbs: [u64; 4],
 }
 
-impl TweedledumBase {
+impl MontyRepr for TweedledumBase {
     /// The order of the field: 28948022309329048855892746252171976963322203655955319056773317069363642105857
     const ORDER: [u64; 4] = [
         11619397960441266177,
@@ -62,60 +61,15 @@ impl TweedledumBase {
 
     /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
     const MU: u64 = 11619397960441266175;
+}
 
+impl TweedledumBase {
     pub fn from_canonical(c: [u64; 4]) -> Self {
-        // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
-        Self {
-            limbs: Self::montgomery_multiply(c, Self::R2),
-        }
+        Self { limbs: Self::from_monty(c) }
     }
 
     pub fn to_canonical(&self) -> [u64; 4] {
-        // Let x * R = self. We compute M(x * R, 1) = x * R * R^-1 = x.
-        Self::montgomery_multiply(self.limbs, [1, 0, 0, 0])
-    }
-
-    #[unroll_for_loops]
-    fn montgomery_multiply(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
-        // Interleaved Montgomery multiplication, as described in Algorithm 2 of
-        // https://eprint.iacr.org/2017/1057.pdf
-
-        // Note that in the loop below, to avoid explicitly shifting c, we will treat i as the least
-        // significant digit and wrap around.
-        let mut c = [0u64; 5];
-
-        for i in 0..4 {
-            // Add a[i] b to c.
-            let mut carry = 0;
-            for j in 0..4 {
-                let result = c[(i + j) % 5] as u128 + a[i] as u128 * b[j] as u128 + carry as u128;
-                c[(i + j) % 5] = result as u64;
-                carry = (result >> 64) as u64;
-            }
-            c[(i + 4) % 5] += carry;
-
-            // q = u c mod r = u c[0] mod r.
-            let q = Self::MU.wrapping_mul(c[i]);
-
-            // C += N q
-            carry = 0;
-            for j in 0..4 {
-                let result =
-                    c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
-                c[(i + j) % 5] = result as u64;
-                carry = (result >> 64) as u64;
-            }
-            c[(i + 4) % 5] += carry;
-
-            debug_assert_eq!(c[i], 0);
-        }
-
-        let mut result = [c[4], c[0], c[1], c[2]];
-        // Final conditional subtraction.
-        if cmp(result, Self::ORDER) != Less {
-            result = sub(result, Self::ORDER);
-        }
-        result
+        Self::to_monty(self.limbs)
     }
 }
 
@@ -123,14 +77,7 @@ impl Add<TweedledumBase> for TweedledumBase {
     type Output = Self;
 
     fn add(self, rhs: TweedledumBase) -> Self::Output {
-        // First we do a widening addition, then we reduce if necessary.
-        let sum = add_no_overflow(self.limbs, rhs.limbs);
-        let limbs = if cmp(sum, Self::ORDER) == Less {
-            sum
-        } else {
-            sub(sum, Self::ORDER)
-        };
-        Self { limbs }
+        Self { limbs: Self::monty_add(self.limbs, rhs.limbs) }
     }
 }
 
@@ -138,14 +85,7 @@ impl Sub<TweedledumBase> for TweedledumBase {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        let limbs = if cmp(self.limbs, rhs.limbs) == Less {
-            // Underflow occurs, so we compute the difference as `self + (-rhs)`.
-            add_no_overflow(self.limbs, (-rhs).limbs)
-        } else {
-            // No underflow, so it's faster to subtract directly.
-            sub(self.limbs, rhs.limbs)
-        };
-        Self { limbs }
+        Self { limbs: Self::monty_sub(self.limbs, rhs.limbs) }
     }
 }
 
@@ -153,9 +93,7 @@ impl Mul<TweedledumBase> for TweedledumBase {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            limbs: Self::montgomery_multiply(self.limbs, rhs.limbs),
-        }
+        Self { limbs: Self::monty_multiply(self.limbs, rhs.limbs) }
     }
 }
 
@@ -171,21 +109,15 @@ impl Neg for TweedledumBase {
     type Output = Self;
 
     fn neg(self) -> Self {
-        if self == Self::ZERO {
-            Self::ZERO
-        } else {
-            Self {
-                limbs: sub(Self::ORDER, self.limbs),
-            }
-        }
+        Self { limbs: Self::monty_neg(self.limbs) }
     }
 }
 
 impl Field for TweedledumBase {
     const BITS: usize = 255;
     const BYTES: usize = 32;
-    const ZERO: Self = Self { limbs: [0; 4] };
-    const ONE: Self = Self { limbs: Self::R };
+    const ZERO: Self = Self { limbs: <Self as MontyRepr>::ZERO };
+    const ONE: Self = Self { limbs: <Self as MontyRepr>::ONE };
     const TWO: Self = Self {
         limbs: [
             10897934645458894841,
@@ -255,10 +187,8 @@ impl Field for TweedledumBase {
     }
 
     fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
-        // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 = x^-1 R.
-        let self_r_inv = nonzero_multiplicative_inverse(self.limbs, Self::ORDER);
         Self {
-            limbs: Self::montgomery_multiply(self_r_inv, Self::R3),
+            limbs: Self::monty_inverse(self.limbs)
         }
     }
 
@@ -271,6 +201,13 @@ impl Field for TweedledumBase {
     fn rand_from_rng<R: Rng>(rng: &mut R) -> Self {
         Self {
             limbs: rand_range_from_rng(Self::ORDER, rng),
+        }
+    }
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        Self {
+            limbs: Self::monty_square(self.limbs),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 #![allow(incomplete_features)]
 
 
-#![feature(const_generics)]
-
 pub use bigint::*;
 pub use circuit_bigint::*;
 pub use circuit_builder::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 // We have tons of bigint literals in Montgomery form, which won't be readable with or without underscores.
 #![allow(clippy::unreadable_literal)]
 
+#![feature(const_generics)]
+
 pub use bigint::*;
 pub use circuit_bigint::*;
 pub use circuit_builder::*;


### PR DESCRIPTION
This PR implements faster modular squaring using the Montgomery CIOS method. The improvement over multiplication comes from observing that only half of the 'off-diagonal' pairs of digits need to be multiplied because of the symmetry of the input.

Main references were [Acar's PhD thesis](https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf) and a [blog post by the Goff team](https://hackmd.io/@zkteam/modular_multiplication) (though I haven't yet implemented the improvement they are talking about at the latter link).

Benchmarking on my laptop suggests this implementation costs 60-70% of the time of the existing Montgomery multiplication function. Specifically multiplication takes around 48ns and squaring around 33ns. (Both drop by a further 5-10% when the conditional subtraction is removed at the end, which will be implemented as part of #74.)

Closes #70. 

ETA: I took the opportunity to refactor the Monty arithmetic from the two Tweedle curves in this PR, so it closes #86 too.