### PR TITLE
Serialization + Logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["plookup"]
 
 [dependencies]
 getrandom = "0.1.14"
-num = "0.2.1"
+num = "0.3.0"
 rand = "0.7.3"
 rayon = "1.3.0"
 unroll = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ anyhow = "1.0.31"
 once_cell = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.1"
-serde_traitobject = "0.2.7"
+log = "0.4"
+pretty_env_logger = "0.4"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ rand_chacha = "0.2.2"
 blake3 = "0.3.3"
 anyhow = "1.0.31"
 once_cell = "1.4.0"
+serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3.1"
+#typetag = "0.1.6"
+serde_traitobject = "0.2.7"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ anyhow = "1.0.31"
 once_cell = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.1"
-#typetag = "0.1.6"
 serde_traitobject = "0.2.7"
 
 [dev-dependencies]

--- a/plookup/Cargo.toml
+++ b/plookup/Cargo.toml
@@ -9,4 +9,4 @@ plonky = {path=".."}
 anyhow = "1.0.31"
 rand = "0.7.3"
 itertools = "0.9.0"
-num = "0.2.1"
+num = "0.3.0"

--- a/src/bigint/bigint_inverse.rs
+++ b/src/bigint/bigint_inverse.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::many_single_char_names)]
 use std::cmp::Ordering::Less;
 
 use crate::{add_4_4_no_overflow, add_6_6_no_overflow, cmp_4_4, cmp_6_6, div2_4, div2_6, is_even_4, is_even_6, is_odd_4, is_odd_6, sub_4_4, sub_6_6};

--- a/src/bin/msms.rs
+++ b/src/bin/msms.rs
@@ -1,8 +1,9 @@
 //! Runs MSMs with various thread pool sizes, and outputs timing data.
+#![allow(clippy::same_item_push)]
 
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
-use plonky::{Curve, Field, msm_execute_parallel, msm_precompute, Tweedledum, MsmPrecomputation};
+use plonky::{msm_execute_parallel, msm_precompute, Curve, Field, MsmPrecomputation, Tweedledum};
 
 type C = Tweedledum;
 type SF = <C as Curve>::ScalarField;
@@ -31,19 +32,25 @@ fn main() {
             durations.sort();
             let average_duration = durations.iter().sum::<Duration>() / durations.len() as u32;
             let average_secs = average_duration.as_secs_f64();
-            println!("MSMs with terms=2^{}, threads={}, window_size={}: avg={:.4}s, avg*threads={:.4}s",
-                     terms_log, threads, window_size,
-                     average_secs, average_secs * threads as f64);
+            println!(
+                "MSMs with terms=2^{}, threads={}, window_size={}: avg={:.4}s, avg*threads={:.4}s",
+                terms_log,
+                threads,
+                window_size,
+                average_secs,
+                average_secs * threads as f64
+            );
         }
     }
 }
 
 fn time_msm(terms: usize, threads: usize, precomputation: &MsmPrecomputation<C>) -> Duration {
-    let scalars: Vec<_> = (0..terms)
-        .map(|_| SF::rand())
-        .collect();
+    let scalars: Vec<_> = (0..terms).map(|_| SF::rand()).collect();
 
-    let pool = rayon::ThreadPoolBuilder::new().num_threads(threads).build().unwrap();
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .unwrap();
 
     pool.install(|| {
         let start = Instant::now();

--- a/src/bin/recursion.rs
+++ b/src/bin/recursion.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use std::time::Instant;
 
-use plonky::{recursive_verification_circuit, verify_proof, BufferGate, Circuit, CircuitBuilder, PartialWitness, Tweedledee, Tweedledum};
+use plonky::{
+    recursive_verification_circuit, verify_proof, BufferGate, Circuit, CircuitBuilder,
+    PartialWitness, Tweedledee, Tweedledum,
+};
 
 const INNER_PROOF_DEGREE_POW: usize = 14;
 const INNER_PROOF_DEGREE: usize = 1 << INNER_PROOF_DEGREE_POW;
@@ -53,7 +56,7 @@ fn main() -> Result<()> {
     let mut recursion_inputs = PartialWitness::new();
     if let Err(e) = recursion_circuit
         .proof
-        .populate_witness(&mut recursion_inputs, inner_proof.clone())
+        .populate_witness(&mut recursion_inputs, inner_proof)
     {
         panic!("Failed to populate inputs: {:?}", e);
     }

--- a/src/bin/recursion.rs
+++ b/src/bin/recursion.rs
@@ -1,10 +1,7 @@
 use anyhow::Result;
 use std::time::Instant;
 
-use plonky::{
-    recursive_verification_circuit, verify_proof, BufferGate, Circuit, CircuitBuilder,
-    PartialWitness, Tweedledee, Tweedledum,
-};
+use plonky::{recursive_verification_circuit, verify_proof, BufferGate, Circuit, CircuitBuilder, PartialWitness, Tweedledee, Tweedledum};
 
 const INNER_PROOF_DEGREE_POW: usize = 14;
 const INNER_PROOF_DEGREE: usize = 1 << INNER_PROOF_DEGREE_POW;

--- a/src/circuit_bigint.rs
+++ b/src/circuit_bigint.rs
@@ -92,7 +92,7 @@ impl<F: Field> From<BoundedTarget<F>> for BigIntTarget<F> {
 }
 
 pub(crate) fn biguint_to_limbs<F: Field>(biguint: &BigUint) -> Vec<F> {
-    let num_limbs = ceil_div_usize(biguint.bits(), LIMB_BITS);
+    let num_limbs = ceil_div_usize(biguint.bits() as usize, LIMB_BITS);
     let base = BigUint::one() << LIMB_BITS;
     (0..num_limbs)
         .map(|i| biguint_to_field((biguint >> i * LIMB_BITS) % &base))
@@ -105,7 +105,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         max: &BigUint,
         validate: bool,
     ) -> BigIntTarget<C::ScalarField> {
-        let num_limbs = ceil_div_usize(max.bits(), LIMB_BITS);
+        let num_limbs = ceil_div_usize(max.bits() as usize, LIMB_BITS);
         let limbs = self.add_virtual_targets(num_limbs);
 
         if validate {

--- a/src/circuit_bigint.rs
+++ b/src/circuit_bigint.rs
@@ -47,7 +47,7 @@ impl<F: Field> BigIntTarget<F> {
 
     pub fn get_bounded_limb(&self, index: usize) -> BoundedTarget<F> {
         // We shift self.max to get the max value of this limb AND any more significant limbs.
-        let max_high_limbs = &self.max >> LIMB_BITS * index;
+        let max_high_limbs = &self.max >> (LIMB_BITS * index);
         let max_any_limb = (BigUint::one() << LIMB_BITS) - BigUint::one();
         let max_this_limb = max_high_limbs.min(max_any_limb);
         BoundedTarget {
@@ -95,7 +95,7 @@ pub(crate) fn biguint_to_limbs<F: Field>(biguint: &BigUint) -> Vec<F> {
     let num_limbs = ceil_div_usize(biguint.bits() as usize, LIMB_BITS);
     let base = BigUint::one() << LIMB_BITS;
     (0..num_limbs)
-        .map(|i| biguint_to_field((biguint >> i * LIMB_BITS) % &base))
+        .map(|i| biguint_to_field((biguint >> (i * LIMB_BITS)) % &base))
         .collect()
 }
 
@@ -235,7 +235,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
                     .limbs
                     .get(0)
                     .cloned()
-                    .unwrap_or(self.zero_wire()),
+                    .unwrap_or_else(|| self.zero_wire()),
             );
 
             // The second limb (or zero if there isn't one) becomes our carry.
@@ -301,7 +301,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let value = witness.get_target(self.input.target);
@@ -426,7 +426,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let x = witness.get_bigint_target(&self.x);

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use std::collections::{BTreeMap, HashMap};
 
 use crate::gates::*;
@@ -109,6 +110,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         self.constant_wire(C::ScalarField::NEG_ONE)
     }
 
+    #[allow(clippy::map_entry)]
     pub fn constant_wire(&mut self, c: C::ScalarField) -> Target<C::ScalarField> {
         if self.constant_wires.contains_key(&c) {
             self.constant_wires[&c]
@@ -152,7 +154,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 _witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let mut result = PartialWitness::new();
@@ -239,7 +241,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let x = witness.get_target(self.x);
@@ -505,7 +507,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let x_value = witness.get_target(self.x);
@@ -631,7 +633,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let x_value = witness.get_target(self.x);
@@ -802,7 +804,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let x = witness.get_target(self.x);
@@ -1059,7 +1061,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 _witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let mut result = PartialWitness::new();

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -992,6 +992,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
     /// Adds a gate to the circuit, without doing any routing.
     pub fn add_gate<G: Gate<C>>(&mut self, gate: G, gate_constants: Vec<C::ScalarField>) {
+        println!("{} {}", self.num_gates(), G::NAME);
         debug_assert!(G::PREFIX.len() + gate_constants.len() <= NUM_CONSTANTS);
 
         // Merge the gate type's prefix bits with the given gate config constants.

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -992,7 +992,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
     /// Adds a gate to the circuit, without doing any routing.
     pub fn add_gate<G: Gate<C>>(&mut self, gate: G, gate_constants: Vec<C::ScalarField>) {
-        println!("{} {}", self.num_gates(), G::NAME);
+        trace!("{} {}", self.num_gates(), G::NAME);
         debug_assert!(G::PREFIX.len() + gate_constants.len() <= NUM_CONSTANTS);
 
         // Merge the gate type's prefix bits with the given gate config constants.
@@ -1077,19 +1077,18 @@ impl<C: HaloCurve> CircuitBuilder<C> {
         }
 
         // Print gate counts.
-        println!("Gate counts:");
+        info!("Gate counts:");
         for (gate, count) in &self.gate_counts {
-            println!("{}: {}", gate, count);
+            info!("{}: {}", gate, count);
         }
-        println!();
 
         // Pad to a power of two.
-        println!("Total gates before padding: {}", self.num_gates());
+        info!("Total gates before padding: {}", self.num_gates());
         while !self.num_gates().is_power_of_two() {
             // Add an empty gate.
             self.add_gate_no_constants(BufferGate::new(self.num_gates()));
         }
-        println!("Total gates after padding: {}", self.num_gates());
+        info!("Total gates after padding: {}", self.num_gates());
 
         let degree = self.num_gates();
         let degree_pow = log2_strict(degree);

--- a/src/circuit_curve.rs
+++ b/src/circuit_curve.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use crate::plonk_util::halo_n;
 use crate::{blake_hash_base_field_to_curve, AffinePoint, Base4SumGate, BufferGate, CircuitBuilder, Curve, CurveAddGate, CurveDblGate, CurveEndoGate, Field, HaloCurve, PartialWitness, Target, Wire, WitnessGenerator};
 use std::marker::PhantomData;
@@ -237,7 +238,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<InnerC::BaseField>>,
+                _constants: &[Vec<InnerC::BaseField>],
                 witness: &PartialWitness<InnerC::BaseField>,
             ) -> PartialWitness<InnerC::BaseField> {
                 let scalar = witness

--- a/src/circuit_ordering.rs
+++ b/src/circuit_ordering.rs
@@ -82,7 +82,7 @@ impl<C: HaloCurve> CircuitBuilder<C> {
 
             fn generate(
                 &self,
-                _constants: &Vec<Vec<F>>,
+                _constants: &[Vec<F>],
                 witness: &PartialWitness<F>,
             ) -> PartialWitness<F> {
                 let lhs = witness.get_target(self.lhs);

--- a/src/curve/curve.rs
+++ b/src/curve/curve.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::many_single_char_names)]
 use std::ops::Neg;
 
 use anyhow::Result;

--- a/src/curve/curve_msm.rs
+++ b/src/curve/curve_msm.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use rayon::prelude::*;
 
 use crate::{affine_multisummation_best, AffinePoint, Curve, Field, ProjectivePoint};
+use serde::{Deserialize, Serialize};
 
 /// In Yao's method, we compute an affine summation for each digit. In a parallel setting, it would
 /// be easiest to assign individual summations to threads, but this would be sub-optimal because
@@ -12,7 +13,7 @@ use crate::{affine_multisummation_best, AffinePoint, Curve, Field, ProjectivePoi
 /// uneven distributions of work among threads.
 const DIGITS_PER_CHUNK: usize = 80;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MsmPrecomputation<C: Curve> {
     /// For each generator (in the order they were passed to `msm_precompute`), contains a vector
     /// of powers, i.e. [(2^w)^i] for i < DIGITS.

--- a/src/curve/curve_msm.rs
+++ b/src/curve/curve_msm.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// uneven distributions of work among threads.
 const DIGITS_PER_CHUNK: usize = 80;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MsmPrecomputation<C: Curve> {
     /// For each generator (in the order they were passed to `msm_precompute`), contains a vector
     /// of powers, i.e. [(2^w)^i] for i < DIGITS.

--- a/src/curve/curve_multiplication.rs
+++ b/src/curve/curve_multiplication.rs
@@ -1,6 +1,6 @@
 use std::ops::Mul;
 
-use crate::{affine_summation_batch_inversion, AffinePoint, Curve, Field, ProjectivePoint, CurveScalar};
+use crate::{affine_summation_batch_inversion, AffinePoint, Curve, CurveScalar, Field, ProjectivePoint};
 
 const WINDOW_BITS: usize = 4;
 const BASE: usize = 1 << WINDOW_BITS;
@@ -69,9 +69,12 @@ impl<C: Curve> Mul<ProjectivePoint<C>> for CurveScalar<C> {
     }
 }
 
+#[allow(clippy::assertions_on_constants)]
 fn to_digits<C: Curve>(x: &C::ScalarField) -> Vec<u64> {
-    debug_assert!(64 % WINDOW_BITS == 0,
-                  "For simplicity, only power-of-two window sizes are handled for now");
+    debug_assert!(
+        64 % WINDOW_BITS == 0,
+        "For simplicity, only power-of-two window sizes are handled for now"
+    );
     let digits_per_u64 = 64 / WINDOW_BITS;
     let mut digits = Vec::with_capacity(digits_per_scalar::<C>());
     for limb in x.to_canonical_u64_vec() {

--- a/src/curve/curve_multiplication.rs
+++ b/src/curve/curve_multiplication.rs
@@ -71,10 +71,8 @@ impl<C: Curve> Mul<ProjectivePoint<C>> for CurveScalar<C> {
 
 #[allow(clippy::assertions_on_constants)]
 fn to_digits<C: Curve>(x: &C::ScalarField) -> Vec<u64> {
-    debug_assert!(
-        64 % WINDOW_BITS == 0,
-        "For simplicity, only power-of-two window sizes are handled for now"
-    );
+    debug_assert!(64 % WINDOW_BITS == 0,
+                  "For simplicity, only power-of-two window sizes are handled for now");
     let digits_per_u64 = 64 / WINDOW_BITS;
     let mut digits = Vec::with_capacity(digits_per_scalar::<C>());
     for limb in x.to_canonical_u64_vec() {

--- a/src/curve/mod.rs
+++ b/src/curve/mod.rs
@@ -8,6 +8,7 @@ pub use tweedledee_curve::*;
 pub use tweedledum_curve::*;
 
 mod bls12_377_curve;
+#[allow(clippy::module_inception)]
 mod curve;
 mod curve_adds;
 mod curve_msm;

--- a/src/curve/tweedledee_curve.rs
+++ b/src/curve/tweedledee_curve.rs
@@ -1,6 +1,7 @@
 use crate::{AffinePoint, Curve, Field, HaloCurve, TweedledeeBase, TweedledumBase};
+use serde::Serialize;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub struct Tweedledee;
 
 impl Curve for Tweedledee {
@@ -39,7 +40,7 @@ impl HaloCurve for Tweedledee {
 #[cfg(test)]
 mod tests {
     use crate::curve::{Curve, HaloCurve, ProjectivePoint};
-    use crate::{Tweedledee, Field};
+    use crate::{Field, Tweedledee};
 
     /// A simple, somewhat inefficient implementation of multiplication which is used as a reference
     /// for correctness.

--- a/src/curve/tweedledee_curve.rs
+++ b/src/curve/tweedledee_curve.rs
@@ -1,7 +1,7 @@
 use crate::{AffinePoint, Curve, Field, HaloCurve, TweedledeeBase, TweedledumBase};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct Tweedledee;
 
 impl Curve for Tweedledee {

--- a/src/curve/tweedledum_curve.rs
+++ b/src/curve/tweedledum_curve.rs
@@ -16,7 +16,7 @@ impl Curve for Tweedledum {
             11556519044732520811,
             18446744073709551615,
             4611686018427387903,
-        ],
+        ]
     };
 
     const GENERATOR_AFFINE: AffinePoint<Self> = AffinePoint {
@@ -27,7 +27,7 @@ impl Curve for Tweedledum {
                 12442237869110527732,
                 9256472484777506843,
                 1114242145010923164,
-            ],
+            ]
         },
         zero: false,
     };
@@ -40,7 +40,7 @@ impl HaloCurve for Tweedledum {
             3132214451552427455,
             3308921103222877309,
             2709928666517121162,
-        ],
+        ]
     };
     const ZETA_SCALAR: Self::ScalarField = TweedledeeBase {
         limbs: [
@@ -48,14 +48,14 @@ impl HaloCurve for Tweedledum {
             16421485501699768486,
             18374227564572127422,
             3902997619921080662,
-        ],
+        ]
     };
 }
 
 #[cfg(test)]
 mod tests {
     use crate::curve::{Curve, HaloCurve, ProjectivePoint};
-    use crate::{Field, Tweedledum};
+    use crate::{Tweedledum, Field};
 
     /// A simple, somewhat inefficient implementation of multiplication which is used as a reference
     /// for correctness.
@@ -82,6 +82,9 @@ mod tests {
         let g = C::convert(<C as Curve>::ScalarField::rand()) * C::GENERATOR_PROJECTIVE;
         let g = g.to_affine();
         let h = g.endomorphism();
-        assert_eq!(h, mul_naive(C::ZETA_SCALAR, g.to_projective()).to_affine());
+        assert_eq!(
+            h,
+            mul_naive(C::ZETA_SCALAR, g.to_projective()).to_affine()
+        );
     }
 }

--- a/src/curve/tweedledum_curve.rs
+++ b/src/curve/tweedledum_curve.rs
@@ -1,6 +1,7 @@
 use crate::{AffinePoint, Curve, Field, HaloCurve, TweedledeeBase, TweedledumBase};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct Tweedledum;
 
 impl Curve for Tweedledum {
@@ -15,7 +16,7 @@ impl Curve for Tweedledum {
             11556519044732520811,
             18446744073709551615,
             4611686018427387903,
-        ]
+        ],
     };
 
     const GENERATOR_AFFINE: AffinePoint<Self> = AffinePoint {
@@ -26,7 +27,7 @@ impl Curve for Tweedledum {
                 12442237869110527732,
                 9256472484777506843,
                 1114242145010923164,
-            ]
+            ],
         },
         zero: false,
     };
@@ -39,7 +40,7 @@ impl HaloCurve for Tweedledum {
             3132214451552427455,
             3308921103222877309,
             2709928666517121162,
-        ]
+        ],
     };
     const ZETA_SCALAR: Self::ScalarField = TweedledeeBase {
         limbs: [
@@ -47,14 +48,14 @@ impl HaloCurve for Tweedledum {
             16421485501699768486,
             18374227564572127422,
             3902997619921080662,
-        ]
+        ],
     };
 }
 
 #[cfg(test)]
 mod tests {
     use crate::curve::{Curve, HaloCurve, ProjectivePoint};
-    use crate::{Tweedledum, Field};
+    use crate::{Field, Tweedledum};
 
     /// A simple, somewhat inefficient implementation of multiplication which is used as a reference
     /// for correctness.
@@ -81,9 +82,6 @@ mod tests {
         let g = C::convert(<C as Curve>::ScalarField::rand()) * C::GENERATOR_PROJECTIVE;
         let g = g.to_affine();
         let h = g.endomorphism();
-        assert_eq!(
-            h,
-            mul_naive(C::ZETA_SCALAR, g.to_projective()).to_affine()
-        );
+        assert_eq!(h, mul_naive(C::ZETA_SCALAR, g.to_projective()).to_affine());
     }
 }

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -2,6 +2,7 @@ use rayon::prelude::*;
 
 use crate::util::{log2_ceil, log2_strict};
 use crate::Field;
+use serde::{Deserialize, Serialize};
 
 /// Permutes `arr` such that each index is mapped to its reverse in binary.
 fn reverse_index_bits<T: Copy>(arr: Vec<T>) -> Vec<T> {
@@ -24,7 +25,7 @@ fn reverse_bits(n: usize, num_bits: usize) -> usize {
     result
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FftPrecomputation<F: Field> {
     /// For each layer index i, stores the cyclic subgroup corresponding to the evaluation domain of
     /// layer i. The indices within these subgroup vectors are bit-reversed.

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -2,7 +2,6 @@ use rayon::prelude::*;
 
 use crate::util::{log2_ceil, log2_strict};
 use crate::Field;
-use serde::{Deserialize, Serialize};
 
 /// Permutes `arr` such that each index is mapped to its reverse in binary.
 fn reverse_index_bits<T: Copy>(arr: Vec<T>) -> Vec<T> {
@@ -25,7 +24,7 @@ fn reverse_bits(n: usize, num_bits: usize) -> usize {
     result
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FftPrecomputation<F: Field> {
     /// For each layer index i, stores the cyclic subgroup corresponding to the evaluation domain of
     /// layer i. The indices within these subgroup vectors are bit-reversed.

--- a/src/field/bls12_377_base.rs
+++ b/src/field/bls12_377_base.rs
@@ -9,13 +9,12 @@ use unroll::unroll_for_loops;
 
 use crate::{add_6_6_no_overflow, cmp_6_6, Field, mul2_6, rand_range_6, rand_range_6_from_rng, sub_6_6, field_to_biguint};
 use crate::nonzero_multiplicative_inverse_6;
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::{Formatter, Display};
 use std::fmt;
 
 /// An element of the BLS12 group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Bls12377Base {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 6],

--- a/src/field/bls12_377_base.rs
+++ b/src/field/bls12_377_base.rs
@@ -1,18 +1,18 @@
 //! This module implements field arithmetic for BLS12-377's base field.
 
-use rand::Rng;
 use std::cmp::Ordering::Less;
 use std::convert::TryInto;
 use std::ops::{Add, Div, Mul, Neg, Sub};
+use rand::Rng;
 
 use unroll::unroll_for_loops;
 
+use crate::{add_6_6_no_overflow, cmp_6_6, Field, mul2_6, rand_range_6, rand_range_6_from_rng, sub_6_6, field_to_biguint};
 use crate::nonzero_multiplicative_inverse_6;
-use crate::{add_6_6_no_overflow, cmp_6_6, field_to_biguint, mul2_6, rand_range_6, rand_range_6_from_rng, sub_6_6, Field};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::fmt::{Formatter, Display};
 use std::fmt;
-use std::fmt::{Display, Formatter};
 
 /// An element of the BLS12 group's base field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, Serialize, Deserialize)]
@@ -24,63 +24,31 @@ pub struct Bls12377Base {
 impl Bls12377Base {
     /// The order of the field:
     /// 258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177
-    pub const ORDER: [u64; 6] = [
-        9586122913090633729,
-        1660523435060625408,
-        2230234197602682880,
-        1883307231910630287,
-        14284016967150029115,
-        121098312706494698,
-    ];
+    pub const ORDER: [u64; 6] = [9586122913090633729, 1660523435060625408, 2230234197602682880,
+        1883307231910630287, 14284016967150029115, 121098312706494698];
 
     /// Twice the order of the field.
-    pub const ORDER_X2: [u64; 6] = [
-        725501752471715842,
-        3321046870121250817,
-        4460468395205365760,
-        3766614463821260574,
-        10121289860590506614,
-        242196625412989397,
-    ];
+    pub const ORDER_X2: [u64; 6] = [725501752471715842, 3321046870121250817, 4460468395205365760,
+        3766614463821260574, 10121289860590506614, 242196625412989397];
 
     /// R in the context of the Montgomery reduction, i.e. 2^384 % |F|.
-    pub(crate) const R: [u64; 6] = [
-        202099033278250856,
-        5854854902718660529,
-        11492539364873682930,
-        8885205928937022213,
-        5545221690922665192,
-        39800542322357402,
-    ];
+    pub(crate) const R: [u64; 6] = [202099033278250856, 5854854902718660529, 11492539364873682930,
+        8885205928937022213, 5545221690922665192, 39800542322357402];
 
     /// R^2 in the context of the Montgomery reduction, i.e. 2^(384*2) % |F|.
-    pub(crate) const R2: [u64; 6] = [
-        13224372171368877346,
-        227991066186625457,
-        2496666625421784173,
-        13825906835078366124,
-        9475172226622360569,
-        30958721782860680,
-    ];
+    pub(crate) const R2: [u64; 6] = [13224372171368877346, 227991066186625457, 2496666625421784173,
+        13825906835078366124, 9475172226622360569, 30958721782860680];
 
     /// R^3 in the context of the Montgomery reduction, i.e. 2(384*3) % |F|.
-    pub(crate) const R3: [u64; 6] = [
-        6349885463227391520,
-        16505482940020594053,
-        3163973454937060627,
-        7650090842119774734,
-        4571808961100582073,
-        73846176275226021,
-    ];
+    pub(crate) const R3: [u64; 6] = [6349885463227391520, 16505482940020594053, 3163973454937060627,
+        7650090842119774734, 4571808961100582073, 73846176275226021];
 
     /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
     const MU: u64 = 9586122913090633727;
 
     pub fn from_canonical(c: [u64; 6]) -> Self {
         // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
-        Self {
-            limbs: Self::montgomery_multiply(c, Self::R2),
-        }
+        Self { limbs: Self::montgomery_multiply(c, Self::R2) }
     }
 
     pub fn to_canonical(&self) -> [u64; 6] {
@@ -113,8 +81,7 @@ impl Bls12377Base {
             // C += N q
             carry = 0;
             for j in 0..6 {
-                let result =
-                    c[(i + j) % 7] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
+                let result = c[(i + j) % 7] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
                 c[(i + j) % 7] = result as u64;
                 carry = (result >> 64) as u64;
             }
@@ -166,9 +133,7 @@ impl Mul<Bls12377Base> for Bls12377Base {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            limbs: Self::montgomery_multiply(self.limbs, rhs.limbs),
-        }
+        Self { limbs: Self::montgomery_multiply(self.limbs, rhs.limbs) }
     }
 }
 
@@ -197,9 +162,7 @@ impl Neg for Bls12377Base {
         if self == Self::ZERO {
             Self::ZERO
         } else {
-            Self {
-                limbs: sub_6_6(Bls12377Base::ORDER, self.limbs),
-            }
+            Self { limbs: sub_6_6(Bls12377Base::ORDER, self.limbs) }
         }
     }
 }
@@ -208,57 +171,29 @@ impl Field for Bls12377Base {
     const BITS: usize = 377;
     const BYTES: usize = 48;
 
-    const ZERO: Self = Self { limbs: [0; 6] };
+    const ZERO: Self = Self {
+        limbs: [0; 6]
+    };
     const ONE: Self = Self { limbs: Self::R };
     const TWO: Self = Self {
-        limbs: [
-            404198066556501712,
-            11709709805437321058,
-            4538334656037814244,
-            17770411857874044427,
-            11090443381845330384,
-            79601084644714804,
-        ],
+        limbs: [404198066556501712, 11709709805437321058, 4538334656037814244, 17770411857874044427,
+            11090443381845330384, 79601084644714804]
     };
     const THREE: Self = Self {
-        limbs: [
-            606297099834752568,
-            17564564708155981587,
-            16030874020911497174,
-            8208873713101515024,
-            16635665072767995577,
-            119401626967072206,
-        ],
+        limbs: [606297099834752568, 17564564708155981587, 16030874020911497174, 8208873713101515024,
+            16635665072767995577, 119401626967072206]
     };
     const FOUR: Self = Self {
-        limbs: [
-            9669017293731921311,
-            3312152102104465091,
-            6846435114472945609,
-            15210772410127906951,
-            7896869796540631654,
-            38103856582934910,
-        ],
+        limbs: [9669017293731921311, 3312152102104465091, 6846435114472945609, 15210772410127906951,
+            7896869796540631654, 38103856582934910]
     };
     const FIVE: Self = Self {
-        limbs: [
-            9871116327010172167,
-            9167007004823125620,
-            18338974479346628539,
-            5649234265355377548,
-            13442091487463296847,
-            77904398905292312,
-        ],
+        limbs: [9871116327010172167, 9167007004823125620, 18338974479346628539, 5649234265355377548,
+            13442091487463296847, 77904398905292312]
     };
     const NEG_ONE: Self = Self {
-        limbs: [
-            9384023879812382873,
-            14252412606051516495,
-            9184438906438551565,
-            11444845376683159689,
-            8738795276227363922,
-            81297770384137296,
-        ],
+        limbs: [9384023879812382873, 14252412606051516495, 9184438906438551565, 11444845376683159689,
+            8738795276227363922, 81297770384137296]
     };
 
     const MULTIPLICATIVE_SUBGROUP_GENERATOR: Self = Self::FIVE;
@@ -268,16 +203,7 @@ impl Field for Bls12377Base {
     const TWO_ADICITY: usize = 46;
 
     // 3675842578061421676390135839012792950148785745837396071634149488243117337281387659330802195819009059
-    const T: Self = Self {
-        limbs: [
-            9586122913090633729,
-            1660523435060625408,
-            2230234197602682880,
-            1883307231910630287,
-            14284016967150029115,
-            121098312706232554,
-        ],
-    };
+    const T: Self = Self { limbs: [9586122913090633729, 1660523435060625408, 2230234197602682880, 1883307231910630287, 14284016967150029115, 121098312706232554]};
 
     fn to_canonical_u64_vec(&self) -> Vec<u64> {
         self.to_canonical().to_vec()
@@ -298,9 +224,7 @@ impl Field for Bls12377Base {
     fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
         // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 = x^-1 R.
         let self_r_inv = nonzero_multiplicative_inverse_6(self.limbs, Self::ORDER);
-        Self {
-            limbs: Self::montgomery_multiply(self_r_inv, Self::R3),
-        }
+        Self { limbs: Self::montgomery_multiply(self_r_inv, Self::R3) }
     }
 
     fn double(&self) -> Self {
@@ -330,15 +254,11 @@ impl Field for Bls12377Base {
     }
 
     fn rand() -> Self {
-        Self {
-            limbs: rand_range_6(Self::ORDER),
-        }
+        Self { limbs: rand_range_6(Self::ORDER) }
     }
 
     fn rand_from_rng<R: Rng>(rng: &mut R) -> Self {
-        Self {
-            limbs: rand_range_6_from_rng(Self::ORDER, rng),
-        }
+        Self { limbs: rand_range_6_from_rng(Self::ORDER, rng) }
     }
 }
 
@@ -362,9 +282,9 @@ impl Display for Bls12377Base {
 
 #[cfg(test)]
 mod tests {
+    use crate::Bls12377Base;
     use crate::conversions::u64_slice_to_biguint;
     use crate::test_arithmetic;
-    use crate::Bls12377Base;
     use crate::Field;
 
     #[test]
@@ -375,10 +295,8 @@ mod tests {
         let r_biguint = u64_slice_to_biguint(&Bls12377Base::R);
 
         let a_bls12base = Bls12377Base::from_canonical(a);
-        assert_eq!(
-            u64_slice_to_biguint(&a_bls12base.limbs),
-            &a_biguint * &r_biguint % &order_biguint
-        );
+        assert_eq!(u64_slice_to_biguint(&a_bls12base.limbs),
+                   &a_biguint * &r_biguint % &order_biguint);
         assert_eq!(u64_slice_to_biguint(&a_bls12base.to_canonical()), a_biguint);
     }
 
@@ -396,8 +314,7 @@ mod tests {
 
         assert_eq!(
             u64_slice_to_biguint(&(a_blsbase * b_blsbase).to_canonical()),
-            a_biguint * b_biguint % order_biguint
-        );
+            a_biguint * b_biguint % order_biguint);
     }
 
     #[test]
@@ -448,22 +365,10 @@ mod tests {
     #[test]
     fn num_bits() {
         assert_eq!(Bls12377Base::from_canonical_u64(0b10101).num_bits(), 5);
-        assert_eq!(
-            Bls12377Base::from_canonical_u64(u64::max_value()).num_bits(),
-            64
-        );
-        assert_eq!(
-            Bls12377Base::from_canonical([0, 1, 0, 0, 0, 0]).num_bits(),
-            64 + 1
-        );
-        assert_eq!(
-            Bls12377Base::from_canonical([0, 0, 0, 0, 0, 1]).num_bits(),
-            64 * 5 + 1
-        );
-        assert_eq!(
-            Bls12377Base::from_canonical([0, 0, 0, 0, 0, 0b10101]).num_bits(),
-            64 * 5 + 5
-        )
+        assert_eq!(Bls12377Base::from_canonical_u64(u64::max_value()).num_bits(), 64);
+        assert_eq!(Bls12377Base::from_canonical([0, 1, 0, 0, 0, 0]).num_bits(), 64 + 1);
+        assert_eq!(Bls12377Base::from_canonical([0, 0, 0, 0, 0, 1]).num_bits(), 64 * 5 + 1);
+        assert_eq!(Bls12377Base::from_canonical([0, 0, 0, 0, 0, 0b10101]).num_bits(), 64 * 5 + 5)
     }
 
     #[test]
@@ -476,14 +381,8 @@ mod tests {
         assert_eq!(Bls12377Base::ONE.kth_root_u32(1), Bls12377Base::ONE);
         assert_eq!(Bls12377Base::FIVE.kth_root_u32(1), Bls12377Base::FIVE);
 
-        assert_eq!(
-            Bls12377Base::FIVE.kth_root_u32(5).exp_u32(5),
-            Bls12377Base::FIVE
-        );
-        assert_eq!(
-            Bls12377Base::FIVE.kth_root_u32(11).exp_u32(11),
-            Bls12377Base::FIVE
-        );
+        assert_eq!(Bls12377Base::FIVE.kth_root_u32(5).exp_u32(5), Bls12377Base::FIVE);
+        assert_eq!(Bls12377Base::FIVE.kth_root_u32(11).exp_u32(11), Bls12377Base::FIVE);
     }
 
     test_arithmetic!(crate::Bls12377Base);

--- a/src/field/bls12_377_base.rs
+++ b/src/field/bls12_377_base.rs
@@ -1,20 +1,21 @@
 //! This module implements field arithmetic for BLS12-377's base field.
 
+use rand::Rng;
 use std::cmp::Ordering::Less;
 use std::convert::TryInto;
 use std::ops::{Add, Div, Mul, Neg, Sub};
-use rand::Rng;
 
 use unroll::unroll_for_loops;
 
-use crate::{add_6_6_no_overflow, cmp_6_6, Field, mul2_6, rand_range_6, rand_range_6_from_rng, sub_6_6, field_to_biguint};
 use crate::nonzero_multiplicative_inverse_6;
+use crate::{add_6_6_no_overflow, cmp_6_6, field_to_biguint, mul2_6, rand_range_6, rand_range_6_from_rng, sub_6_6, Field};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::fmt::{Formatter, Display};
 use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// An element of the BLS12 group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, Serialize, Deserialize)]
 pub struct Bls12377Base {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 6],
@@ -23,31 +24,63 @@ pub struct Bls12377Base {
 impl Bls12377Base {
     /// The order of the field:
     /// 258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177
-    pub const ORDER: [u64; 6] = [9586122913090633729, 1660523435060625408, 2230234197602682880,
-        1883307231910630287, 14284016967150029115, 121098312706494698];
+    pub const ORDER: [u64; 6] = [
+        9586122913090633729,
+        1660523435060625408,
+        2230234197602682880,
+        1883307231910630287,
+        14284016967150029115,
+        121098312706494698,
+    ];
 
     /// Twice the order of the field.
-    pub const ORDER_X2: [u64; 6] = [725501752471715842, 3321046870121250817, 4460468395205365760,
-        3766614463821260574, 10121289860590506614, 242196625412989397];
+    pub const ORDER_X2: [u64; 6] = [
+        725501752471715842,
+        3321046870121250817,
+        4460468395205365760,
+        3766614463821260574,
+        10121289860590506614,
+        242196625412989397,
+    ];
 
     /// R in the context of the Montgomery reduction, i.e. 2^384 % |F|.
-    pub(crate) const R: [u64; 6] = [202099033278250856, 5854854902718660529, 11492539364873682930,
-        8885205928937022213, 5545221690922665192, 39800542322357402];
+    pub(crate) const R: [u64; 6] = [
+        202099033278250856,
+        5854854902718660529,
+        11492539364873682930,
+        8885205928937022213,
+        5545221690922665192,
+        39800542322357402,
+    ];
 
     /// R^2 in the context of the Montgomery reduction, i.e. 2^(384*2) % |F|.
-    pub(crate) const R2: [u64; 6] = [13224372171368877346, 227991066186625457, 2496666625421784173,
-        13825906835078366124, 9475172226622360569, 30958721782860680];
+    pub(crate) const R2: [u64; 6] = [
+        13224372171368877346,
+        227991066186625457,
+        2496666625421784173,
+        13825906835078366124,
+        9475172226622360569,
+        30958721782860680,
+    ];
 
     /// R^3 in the context of the Montgomery reduction, i.e. 2(384*3) % |F|.
-    pub(crate) const R3: [u64; 6] = [6349885463227391520, 16505482940020594053, 3163973454937060627,
-        7650090842119774734, 4571808961100582073, 73846176275226021];
+    pub(crate) const R3: [u64; 6] = [
+        6349885463227391520,
+        16505482940020594053,
+        3163973454937060627,
+        7650090842119774734,
+        4571808961100582073,
+        73846176275226021,
+    ];
 
     /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
     const MU: u64 = 9586122913090633727;
 
     pub fn from_canonical(c: [u64; 6]) -> Self {
         // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
-        Self { limbs: Self::montgomery_multiply(c, Self::R2) }
+        Self {
+            limbs: Self::montgomery_multiply(c, Self::R2),
+        }
     }
 
     pub fn to_canonical(&self) -> [u64; 6] {
@@ -80,7 +113,8 @@ impl Bls12377Base {
             // C += N q
             carry = 0;
             for j in 0..6 {
-                let result = c[(i + j) % 7] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
+                let result =
+                    c[(i + j) % 7] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
                 c[(i + j) % 7] = result as u64;
                 carry = (result >> 64) as u64;
             }
@@ -132,7 +166,9 @@ impl Mul<Bls12377Base> for Bls12377Base {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
-        Self { limbs: Self::montgomery_multiply(self.limbs, rhs.limbs) }
+        Self {
+            limbs: Self::montgomery_multiply(self.limbs, rhs.limbs),
+        }
     }
 }
 
@@ -161,7 +197,9 @@ impl Neg for Bls12377Base {
         if self == Self::ZERO {
             Self::ZERO
         } else {
-            Self { limbs: sub_6_6(Bls12377Base::ORDER, self.limbs) }
+            Self {
+                limbs: sub_6_6(Bls12377Base::ORDER, self.limbs),
+            }
         }
     }
 }
@@ -170,29 +208,57 @@ impl Field for Bls12377Base {
     const BITS: usize = 377;
     const BYTES: usize = 48;
 
-    const ZERO: Self = Self {
-        limbs: [0; 6]
-    };
+    const ZERO: Self = Self { limbs: [0; 6] };
     const ONE: Self = Self { limbs: Self::R };
     const TWO: Self = Self {
-        limbs: [404198066556501712, 11709709805437321058, 4538334656037814244, 17770411857874044427,
-            11090443381845330384, 79601084644714804]
+        limbs: [
+            404198066556501712,
+            11709709805437321058,
+            4538334656037814244,
+            17770411857874044427,
+            11090443381845330384,
+            79601084644714804,
+        ],
     };
     const THREE: Self = Self {
-        limbs: [606297099834752568, 17564564708155981587, 16030874020911497174, 8208873713101515024,
-            16635665072767995577, 119401626967072206]
+        limbs: [
+            606297099834752568,
+            17564564708155981587,
+            16030874020911497174,
+            8208873713101515024,
+            16635665072767995577,
+            119401626967072206,
+        ],
     };
     const FOUR: Self = Self {
-        limbs: [9669017293731921311, 3312152102104465091, 6846435114472945609, 15210772410127906951,
-            7896869796540631654, 38103856582934910]
+        limbs: [
+            9669017293731921311,
+            3312152102104465091,
+            6846435114472945609,
+            15210772410127906951,
+            7896869796540631654,
+            38103856582934910,
+        ],
     };
     const FIVE: Self = Self {
-        limbs: [9871116327010172167, 9167007004823125620, 18338974479346628539, 5649234265355377548,
-            13442091487463296847, 77904398905292312]
+        limbs: [
+            9871116327010172167,
+            9167007004823125620,
+            18338974479346628539,
+            5649234265355377548,
+            13442091487463296847,
+            77904398905292312,
+        ],
     };
     const NEG_ONE: Self = Self {
-        limbs: [9384023879812382873, 14252412606051516495, 9184438906438551565, 11444845376683159689,
-            8738795276227363922, 81297770384137296]
+        limbs: [
+            9384023879812382873,
+            14252412606051516495,
+            9184438906438551565,
+            11444845376683159689,
+            8738795276227363922,
+            81297770384137296,
+        ],
     };
 
     const MULTIPLICATIVE_SUBGROUP_GENERATOR: Self = Self::FIVE;
@@ -202,7 +268,16 @@ impl Field for Bls12377Base {
     const TWO_ADICITY: usize = 46;
 
     // 3675842578061421676390135839012792950148785745837396071634149488243117337281387659330802195819009059
-    const T: Self = Self { limbs: [9586122913090633729, 1660523435060625408, 2230234197602682880, 1883307231910630287, 14284016967150029115, 121098312706232554]};
+    const T: Self = Self {
+        limbs: [
+            9586122913090633729,
+            1660523435060625408,
+            2230234197602682880,
+            1883307231910630287,
+            14284016967150029115,
+            121098312706232554,
+        ],
+    };
 
     fn to_canonical_u64_vec(&self) -> Vec<u64> {
         self.to_canonical().to_vec()
@@ -223,7 +298,9 @@ impl Field for Bls12377Base {
     fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
         // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 = x^-1 R.
         let self_r_inv = nonzero_multiplicative_inverse_6(self.limbs, Self::ORDER);
-        Self { limbs: Self::montgomery_multiply(self_r_inv, Self::R3) }
+        Self {
+            limbs: Self::montgomery_multiply(self_r_inv, Self::R3),
+        }
     }
 
     fn double(&self) -> Self {
@@ -253,11 +330,15 @@ impl Field for Bls12377Base {
     }
 
     fn rand() -> Self {
-        Self { limbs: rand_range_6(Self::ORDER) }
+        Self {
+            limbs: rand_range_6(Self::ORDER),
+        }
     }
 
     fn rand_from_rng<R: Rng>(rng: &mut R) -> Self {
-        Self { limbs: rand_range_6_from_rng(Self::ORDER, rng) }
+        Self {
+            limbs: rand_range_6_from_rng(Self::ORDER, rng),
+        }
     }
 }
 
@@ -281,9 +362,9 @@ impl Display for Bls12377Base {
 
 #[cfg(test)]
 mod tests {
-    use crate::Bls12377Base;
     use crate::conversions::u64_slice_to_biguint;
     use crate::test_arithmetic;
+    use crate::Bls12377Base;
     use crate::Field;
 
     #[test]
@@ -294,8 +375,10 @@ mod tests {
         let r_biguint = u64_slice_to_biguint(&Bls12377Base::R);
 
         let a_bls12base = Bls12377Base::from_canonical(a);
-        assert_eq!(u64_slice_to_biguint(&a_bls12base.limbs),
-                   &a_biguint * &r_biguint % &order_biguint);
+        assert_eq!(
+            u64_slice_to_biguint(&a_bls12base.limbs),
+            &a_biguint * &r_biguint % &order_biguint
+        );
         assert_eq!(u64_slice_to_biguint(&a_bls12base.to_canonical()), a_biguint);
     }
 
@@ -313,7 +396,8 @@ mod tests {
 
         assert_eq!(
             u64_slice_to_biguint(&(a_blsbase * b_blsbase).to_canonical()),
-            a_biguint * b_biguint % order_biguint);
+            a_biguint * b_biguint % order_biguint
+        );
     }
 
     #[test]
@@ -364,10 +448,22 @@ mod tests {
     #[test]
     fn num_bits() {
         assert_eq!(Bls12377Base::from_canonical_u64(0b10101).num_bits(), 5);
-        assert_eq!(Bls12377Base::from_canonical_u64(u64::max_value()).num_bits(), 64);
-        assert_eq!(Bls12377Base::from_canonical([0, 1, 0, 0, 0, 0]).num_bits(), 64 + 1);
-        assert_eq!(Bls12377Base::from_canonical([0, 0, 0, 0, 0, 1]).num_bits(), 64 * 5 + 1);
-        assert_eq!(Bls12377Base::from_canonical([0, 0, 0, 0, 0, 0b10101]).num_bits(), 64 * 5 + 5)
+        assert_eq!(
+            Bls12377Base::from_canonical_u64(u64::max_value()).num_bits(),
+            64
+        );
+        assert_eq!(
+            Bls12377Base::from_canonical([0, 1, 0, 0, 0, 0]).num_bits(),
+            64 + 1
+        );
+        assert_eq!(
+            Bls12377Base::from_canonical([0, 0, 0, 0, 0, 1]).num_bits(),
+            64 * 5 + 1
+        );
+        assert_eq!(
+            Bls12377Base::from_canonical([0, 0, 0, 0, 0, 0b10101]).num_bits(),
+            64 * 5 + 5
+        )
     }
 
     #[test]
@@ -380,8 +476,14 @@ mod tests {
         assert_eq!(Bls12377Base::ONE.kth_root_u32(1), Bls12377Base::ONE);
         assert_eq!(Bls12377Base::FIVE.kth_root_u32(1), Bls12377Base::FIVE);
 
-        assert_eq!(Bls12377Base::FIVE.kth_root_u32(5).exp_u32(5), Bls12377Base::FIVE);
-        assert_eq!(Bls12377Base::FIVE.kth_root_u32(11).exp_u32(11), Bls12377Base::FIVE);
+        assert_eq!(
+            Bls12377Base::FIVE.kth_root_u32(5).exp_u32(5),
+            Bls12377Base::FIVE
+        );
+        assert_eq!(
+            Bls12377Base::FIVE.kth_root_u32(11).exp_u32(11),
+            Bls12377Base::FIVE
+        );
     }
 
     test_arithmetic!(crate::Bls12377Base);

--- a/src/field/bls12_377_base.rs
+++ b/src/field/bls12_377_base.rs
@@ -291,7 +291,7 @@ impl Field for Bls12377Base {
         Self::from_canonical([n, 0, 0, 0, 0, 0])
     }
 
-    fn is_valid_canonical_u64(v: &Vec<u64>) -> bool {
+    fn is_valid_canonical_u64(v: &[u64]) -> bool {
         v.len() == 6 && cmp_6_6(v[..].try_into().unwrap(), Self::ORDER) == Less
     }
 

--- a/src/field/bls12_377_scalar.rs
+++ b/src/field/bls12_377_scalar.rs
@@ -266,7 +266,7 @@ impl Field for Bls12377Scalar {
         Self::from_canonical([n, 0, 0, 0])
     }
 
-    fn is_valid_canonical_u64(v: &Vec<u64>) -> bool {
+    fn is_valid_canonical_u64(v: &[u64]) -> bool {
         v.len() == 4 && cmp_4_4(v[..].try_into().unwrap(), Self::ORDER) == Less
     }
 

--- a/src/field/bls12_377_scalar.rs
+++ b/src/field/bls12_377_scalar.rs
@@ -1,20 +1,21 @@
 //! This module implements field arithmetic for BLS12-377's scalar field.
 
+use rand::Rng;
 use std::cmp::Ordering::Less;
 use std::convert::TryInto;
 use std::ops::{Add, Div, Mul, Neg, Sub};
-use rand::Rng;
 
 use unroll::unroll_for_loops;
 
-use crate::{add_4_4_no_overflow, cmp_4_4, Field, sub_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng};
 use crate::nonzero_multiplicative_inverse_4;
+use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
 /// An element of the BLS12 group's scalar field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, Serialize, Deserialize)]
 pub struct Bls12377Scalar {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],
@@ -23,33 +24,51 @@ pub struct Bls12377Scalar {
 impl Bls12377Scalar {
     /// The order of the field:
     /// 8444461749428370424248824938781546531375899335154063827935233455917409239041
-    pub const ORDER: [u64; 4] = [725501752471715841, 6461107452199829505, 6968279316240510977, 1345280370688173398];
+    pub const ORDER: [u64; 4] = [
+        725501752471715841,
+        6461107452199829505,
+        6968279316240510977,
+        1345280370688173398,
+    ];
 
     /// R in the context of the Montgomery reduction, i.e. 2^256 % |F|.
-    pub(crate) const R: [u64; 4] =
-        [9015221291577245683, 8239323489949974514, 1646089257421115374, 958099254763297437];
+    pub(crate) const R: [u64; 4] = [
+        9015221291577245683,
+        8239323489949974514,
+        1646089257421115374,
+        958099254763297437,
+    ];
 
     /// R^2 in the context of the Montgomery reduction, i.e. 2^256^2 % |F|.
-    pub(crate) const R2: [u64; 4] =
-        [2726216793283724667, 14712177743343147295, 12091039717619697043, 81024008013859129];
+    pub(crate) const R2: [u64; 4] = [
+        2726216793283724667,
+        14712177743343147295,
+        12091039717619697043,
+        81024008013859129,
+    ];
 
     /// R^3 in the context of the Montgomery reduction, i.e. 2^256^3 % |F|.
-    pub(crate) const R3: [u64; 4] =
-        [7656847007262524748, 7083357369969088153, 12818756329091487507, 432872940405820890];
+    pub(crate) const R3: [u64; 4] = [
+        7656847007262524748,
+        7083357369969088153,
+        12818756329091487507,
+        432872940405820890,
+    ];
 
     /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
     const MU: u64 = 725501752471715839;
 
     pub fn from_canonical(c: [u64; 4]) -> Self {
         // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
-        Self { limbs: Self::montgomery_multiply(c, Self::R2) }
+        Self {
+            limbs: Self::montgomery_multiply(c, Self::R2),
+        }
     }
 
     pub fn to_canonical(&self) -> [u64; 4] {
         // Let x * R = self. We compute M(x * R, 1) = x * R * R^-1 = x.
         Self::montgomery_multiply(self.limbs, [1, 0, 0, 0])
     }
-
 
     #[unroll_for_loops]
     fn montgomery_multiply(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
@@ -76,7 +95,8 @@ impl Bls12377Scalar {
             // C += N q
             carry = 0;
             for j in 0..4 {
-                let result = c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
+                let result =
+                    c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
                 c[(i + j) % 5] = result as u64;
                 carry = (result >> 64) as u64;
             }
@@ -128,7 +148,9 @@ impl Mul<Self> for Bls12377Scalar {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
-        Self { limbs: Self::montgomery_multiply(self.limbs, rhs.limbs) }
+        Self {
+            limbs: Self::montgomery_multiply(self.limbs, rhs.limbs),
+        }
     }
 }
 
@@ -147,7 +169,9 @@ impl Neg for Bls12377Scalar {
         if self == Self::ZERO {
             Self::ZERO
         } else {
-            Self { limbs: sub_4_4(Self::ORDER, self.limbs) }
+            Self {
+                limbs: sub_4_4(Self::ORDER, self.limbs),
+            }
         }
     }
 }
@@ -158,21 +182,77 @@ impl Field for Bls12377Scalar {
 
     const ZERO: Self = Self { limbs: [0; 4] };
     const ONE: Self = Self { limbs: Self::R };
-    const TWO: Self = Self { limbs: [17304940830682775525, 10017539527700119523, 14770643272311271387, 570918138838421475] };
-    const THREE: Self = Self { limbs: [7147916296078753751, 11795755565450264533, 9448453213491875784, 183737022913545514] };
-    const FOUR: Self = Self { limbs: [16163137587655999434, 1588334981690687431, 11094542470912991159, 1141836277676842951] };
-    const FIVE: Self = Self { limbs: [6006113053051977660, 3366551019440832441, 5772352412093595556, 754655161751966990] };
-    const NEG_ONE: Self = Self { limbs: [10157024534604021774, 16668528035959406606, 5322190058819395602, 387181115924875961] };
+    const TWO: Self = Self {
+        limbs: [
+            17304940830682775525,
+            10017539527700119523,
+            14770643272311271387,
+            570918138838421475,
+        ],
+    };
+    const THREE: Self = Self {
+        limbs: [
+            7147916296078753751,
+            11795755565450264533,
+            9448453213491875784,
+            183737022913545514,
+        ],
+    };
+    const FOUR: Self = Self {
+        limbs: [
+            16163137587655999434,
+            1588334981690687431,
+            11094542470912991159,
+            1141836277676842951,
+        ],
+    };
+    const FIVE: Self = Self {
+        limbs: [
+            6006113053051977660,
+            3366551019440832441,
+            5772352412093595556,
+            754655161751966990,
+        ],
+    };
+    const NEG_ONE: Self = Self {
+        limbs: [
+            10157024534604021774,
+            16668528035959406606,
+            5322190058819395602,
+            387181115924875961,
+        ],
+    };
 
-    const MULTIPLICATIVE_SUBGROUP_GENERATOR: Self = Self { limbs: [1855201571499933546, 8511318076631809892, 6222514765367795509, 1122129207579058019] };
+    const MULTIPLICATIVE_SUBGROUP_GENERATOR: Self = Self {
+        limbs: [
+            1855201571499933546,
+            8511318076631809892,
+            6222514765367795509,
+            1122129207579058019,
+        ],
+    };
 
     /// x^11 is a permutation in this field.
-    const ALPHA: Self = Self { limbs: [1855201571499933546, 8511318076631809892, 6222514765367795509, 1122129207579058019] };
+    const ALPHA: Self = Self {
+        limbs: [
+            1855201571499933546,
+            8511318076631809892,
+            6222514765367795509,
+            1122129207579058019,
+        ],
+    };
 
     const TWO_ADICITY: usize = 47;
 
     /// 60001509534603559531609739528203892656505753216962260608619555
-    const T: Self = Self { limbs: [725501752471715841, 6461107452199829505, 6968279316240510977, 1345280370688042326] };
+    const T: Self = Self {
+        limbs: [
+            725501752471715841,
+            6461107452199829505,
+            6968279316240510977,
+            1345280370688042326,
+        ],
+    };
 
     fn to_canonical_u64_vec(&self) -> Vec<u64> {
         self.to_canonical().to_vec()
@@ -193,7 +273,9 @@ impl Field for Bls12377Scalar {
     fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
         // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 = x^-1 R.
         let self_r_inv = nonzero_multiplicative_inverse_4(self.limbs, Self::ORDER);
-        Self { limbs: Self::montgomery_multiply(self_r_inv, Self::R3) }
+        Self {
+            limbs: Self::montgomery_multiply(self_r_inv, Self::R3),
+        }
     }
 
     fn rand() -> Self {
@@ -207,8 +289,6 @@ impl Field for Bls12377Scalar {
             limbs: rand_range_4_from_rng(Self::ORDER, rng),
         }
     }
-
-
 }
 
 impl Ord for Bls12377Scalar {
@@ -229,12 +309,11 @@ impl Display for Bls12377Scalar {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::{Bls12377Scalar, Field};
     use crate::conversions::u64_slice_to_biguint;
     use crate::test_arithmetic;
+    use crate::{Bls12377Scalar, Field};
 
     #[test]
     fn bls12scalar_to_and_from_canonical() {
@@ -244,9 +323,14 @@ mod tests {
         let r_biguint = u64_slice_to_biguint(&Bls12377Scalar::R);
 
         let a_bls12scalar = Bls12377Scalar::from_canonical(a);
-        assert_eq!(u64_slice_to_biguint(&a_bls12scalar.limbs),
-                   &a_biguint * &r_biguint % &order_biguint);
-        assert_eq!(u64_slice_to_biguint(&a_bls12scalar.to_canonical()), a_biguint);
+        assert_eq!(
+            u64_slice_to_biguint(&a_bls12scalar.limbs),
+            &a_biguint * &r_biguint % &order_biguint
+        );
+        assert_eq!(
+            u64_slice_to_biguint(&a_bls12scalar.to_canonical()),
+            a_biguint
+        );
     }
 
     #[test]
@@ -263,7 +347,8 @@ mod tests {
 
         assert_eq!(
             u64_slice_to_biguint(&(a_blsbase * b_blsbase).to_canonical()),
-            a_biguint * b_biguint % order_biguint);
+            a_biguint * b_biguint % order_biguint
+        );
     }
 
     #[test]
@@ -277,10 +362,22 @@ mod tests {
 
     #[test]
     fn exp() {
-        assert_eq!(Bls12377Scalar::THREE.exp(Bls12377Scalar::ZERO), Bls12377Scalar::ONE);
-        assert_eq!(Bls12377Scalar::THREE.exp(Bls12377Scalar::ONE), Bls12377Scalar::THREE);
-        assert_eq!(Bls12377Scalar::THREE.exp(Bls12377Scalar::from_canonical_u64(2)), Bls12377Scalar::from_canonical_u64(9));
-        assert_eq!(Bls12377Scalar::THREE.exp(Bls12377Scalar::from_canonical_u64(3)), Bls12377Scalar::from_canonical_u64(27));
+        assert_eq!(
+            Bls12377Scalar::THREE.exp(Bls12377Scalar::ZERO),
+            Bls12377Scalar::ONE
+        );
+        assert_eq!(
+            Bls12377Scalar::THREE.exp(Bls12377Scalar::ONE),
+            Bls12377Scalar::THREE
+        );
+        assert_eq!(
+            Bls12377Scalar::THREE.exp(Bls12377Scalar::from_canonical_u64(2)),
+            Bls12377Scalar::from_canonical_u64(9)
+        );
+        assert_eq!(
+            Bls12377Scalar::THREE.exp(Bls12377Scalar::from_canonical_u64(3)),
+            Bls12377Scalar::from_canonical_u64(27)
+        );
     }
 
     #[test]
@@ -322,10 +419,22 @@ mod tests {
     #[test]
     fn num_bits() {
         assert_eq!(Bls12377Scalar::from_canonical_u64(0b10101).num_bits(), 5);
-        assert_eq!(Bls12377Scalar::from_canonical_u64(u64::max_value()).num_bits(), 64);
-        assert_eq!(Bls12377Scalar::from_canonical([0, 1, 0, 0]).num_bits(), 64 + 1);
-        assert_eq!(Bls12377Scalar::from_canonical([0, 0, 0, 1]).num_bits(), 64 * 3 + 1);
-        assert_eq!(Bls12377Scalar::from_canonical([0, 0, 0, 0b10101]).num_bits(), 64 * 3 + 5)
+        assert_eq!(
+            Bls12377Scalar::from_canonical_u64(u64::max_value()).num_bits(),
+            64
+        );
+        assert_eq!(
+            Bls12377Scalar::from_canonical([0, 1, 0, 0]).num_bits(),
+            64 + 1
+        );
+        assert_eq!(
+            Bls12377Scalar::from_canonical([0, 0, 0, 1]).num_bits(),
+            64 * 3 + 1
+        );
+        assert_eq!(
+            Bls12377Scalar::from_canonical([0, 0, 0, 0b10101]).num_bits(),
+            64 * 3 + 5
+        )
     }
 
     #[test]
@@ -334,10 +443,16 @@ mod tests {
             let n = 1 << n_power as u64;
             let root = Bls12377Scalar::primitive_root_of_unity(n_power);
 
-            assert_eq!(root.exp(Bls12377Scalar::from_canonical_u64(n)), Bls12377Scalar::ONE);
+            assert_eq!(
+                root.exp(Bls12377Scalar::from_canonical_u64(n)),
+                Bls12377Scalar::ONE
+            );
 
             if n > 1 {
-                assert_ne!(root.exp(Bls12377Scalar::from_canonical_u64(n - 1)), Bls12377Scalar::ONE)
+                assert_ne!(
+                    root.exp(Bls12377Scalar::from_canonical_u64(n - 1)),
+                    Bls12377Scalar::ONE
+                )
             }
         }
     }

--- a/src/field/bls12_377_scalar.rs
+++ b/src/field/bls12_377_scalar.rs
@@ -9,13 +9,12 @@ use unroll::unroll_for_loops;
 
 use crate::{add_4_4_no_overflow, cmp_4_4, Field, sub_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng};
 use crate::nonzero_multiplicative_inverse_4;
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
 /// An element of the BLS12 group's scalar field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Bls12377Scalar {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],

--- a/src/field/bls12_377_scalar.rs
+++ b/src/field/bls12_377_scalar.rs
@@ -1,14 +1,14 @@
 //! This module implements field arithmetic for BLS12-377's scalar field.
 
-use rand::Rng;
 use std::cmp::Ordering::Less;
 use std::convert::TryInto;
 use std::ops::{Add, Div, Mul, Neg, Sub};
+use rand::Rng;
 
 use unroll::unroll_for_loops;
 
+use crate::{add_4_4_no_overflow, cmp_4_4, Field, sub_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng};
 use crate::nonzero_multiplicative_inverse_4;
-use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
@@ -24,45 +24,26 @@ pub struct Bls12377Scalar {
 impl Bls12377Scalar {
     /// The order of the field:
     /// 8444461749428370424248824938781546531375899335154063827935233455917409239041
-    pub const ORDER: [u64; 4] = [
-        725501752471715841,
-        6461107452199829505,
-        6968279316240510977,
-        1345280370688173398,
-    ];
+    pub const ORDER: [u64; 4] = [725501752471715841, 6461107452199829505, 6968279316240510977, 1345280370688173398];
 
     /// R in the context of the Montgomery reduction, i.e. 2^256 % |F|.
-    pub(crate) const R: [u64; 4] = [
-        9015221291577245683,
-        8239323489949974514,
-        1646089257421115374,
-        958099254763297437,
-    ];
+    pub(crate) const R: [u64; 4] =
+        [9015221291577245683, 8239323489949974514, 1646089257421115374, 958099254763297437];
 
     /// R^2 in the context of the Montgomery reduction, i.e. 2^256^2 % |F|.
-    pub(crate) const R2: [u64; 4] = [
-        2726216793283724667,
-        14712177743343147295,
-        12091039717619697043,
-        81024008013859129,
-    ];
+    pub(crate) const R2: [u64; 4] =
+        [2726216793283724667, 14712177743343147295, 12091039717619697043, 81024008013859129];
 
     /// R^3 in the context of the Montgomery reduction, i.e. 2^256^3 % |F|.
-    pub(crate) const R3: [u64; 4] = [
-        7656847007262524748,
-        7083357369969088153,
-        12818756329091487507,
-        432872940405820890,
-    ];
+    pub(crate) const R3: [u64; 4] =
+        [7656847007262524748, 7083357369969088153, 12818756329091487507, 432872940405820890];
 
     /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
     const MU: u64 = 725501752471715839;
 
     pub fn from_canonical(c: [u64; 4]) -> Self {
         // We compute M(c, R^2) = c * R^2 * R^-1 = c * R.
-        Self {
-            limbs: Self::montgomery_multiply(c, Self::R2),
-        }
+        Self { limbs: Self::montgomery_multiply(c, Self::R2) }
     }
 
     pub fn to_canonical(&self) -> [u64; 4] {
@@ -95,8 +76,7 @@ impl Bls12377Scalar {
             // C += N q
             carry = 0;
             for j in 0..4 {
-                let result =
-                    c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
+                let result = c[(i + j) % 5] as u128 + q as u128 * Self::ORDER[j] as u128 + carry as u128;
                 c[(i + j) % 5] = result as u64;
                 carry = (result >> 64) as u64;
             }
@@ -148,9 +128,7 @@ impl Mul<Self> for Bls12377Scalar {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            limbs: Self::montgomery_multiply(self.limbs, rhs.limbs),
-        }
+        Self { limbs: Self::montgomery_multiply(self.limbs, rhs.limbs) }
     }
 }
 
@@ -169,9 +147,7 @@ impl Neg for Bls12377Scalar {
         if self == Self::ZERO {
             Self::ZERO
         } else {
-            Self {
-                limbs: sub_4_4(Self::ORDER, self.limbs),
-            }
+            Self { limbs: sub_4_4(Self::ORDER, self.limbs) }
         }
     }
 }
@@ -182,77 +158,21 @@ impl Field for Bls12377Scalar {
 
     const ZERO: Self = Self { limbs: [0; 4] };
     const ONE: Self = Self { limbs: Self::R };
-    const TWO: Self = Self {
-        limbs: [
-            17304940830682775525,
-            10017539527700119523,
-            14770643272311271387,
-            570918138838421475,
-        ],
-    };
-    const THREE: Self = Self {
-        limbs: [
-            7147916296078753751,
-            11795755565450264533,
-            9448453213491875784,
-            183737022913545514,
-        ],
-    };
-    const FOUR: Self = Self {
-        limbs: [
-            16163137587655999434,
-            1588334981690687431,
-            11094542470912991159,
-            1141836277676842951,
-        ],
-    };
-    const FIVE: Self = Self {
-        limbs: [
-            6006113053051977660,
-            3366551019440832441,
-            5772352412093595556,
-            754655161751966990,
-        ],
-    };
-    const NEG_ONE: Self = Self {
-        limbs: [
-            10157024534604021774,
-            16668528035959406606,
-            5322190058819395602,
-            387181115924875961,
-        ],
-    };
+    const TWO: Self = Self { limbs: [17304940830682775525, 10017539527700119523, 14770643272311271387, 570918138838421475] };
+    const THREE: Self = Self { limbs: [7147916296078753751, 11795755565450264533, 9448453213491875784, 183737022913545514] };
+    const FOUR: Self = Self { limbs: [16163137587655999434, 1588334981690687431, 11094542470912991159, 1141836277676842951] };
+    const FIVE: Self = Self { limbs: [6006113053051977660, 3366551019440832441, 5772352412093595556, 754655161751966990] };
+    const NEG_ONE: Self = Self { limbs: [10157024534604021774, 16668528035959406606, 5322190058819395602, 387181115924875961] };
 
-    const MULTIPLICATIVE_SUBGROUP_GENERATOR: Self = Self {
-        limbs: [
-            1855201571499933546,
-            8511318076631809892,
-            6222514765367795509,
-            1122129207579058019,
-        ],
-    };
+    const MULTIPLICATIVE_SUBGROUP_GENERATOR: Self = Self { limbs: [1855201571499933546, 8511318076631809892, 6222514765367795509, 1122129207579058019] };
 
     /// x^11 is a permutation in this field.
-    const ALPHA: Self = Self {
-        limbs: [
-            1855201571499933546,
-            8511318076631809892,
-            6222514765367795509,
-            1122129207579058019,
-        ],
-    };
+    const ALPHA: Self = Self { limbs: [1855201571499933546, 8511318076631809892, 6222514765367795509, 1122129207579058019] };
 
     const TWO_ADICITY: usize = 47;
 
     /// 60001509534603559531609739528203892656505753216962260608619555
-    const T: Self = Self {
-        limbs: [
-            725501752471715841,
-            6461107452199829505,
-            6968279316240510977,
-            1345280370688042326,
-        ],
-    };
+    const T: Self = Self { limbs: [725501752471715841, 6461107452199829505, 6968279316240510977, 1345280370688042326] };
 
     fn to_canonical_u64_vec(&self) -> Vec<u64> {
         self.to_canonical().to_vec()
@@ -273,9 +193,7 @@ impl Field for Bls12377Scalar {
     fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
         // Let x R = self. We compute M((x R)^-1, R^3) = x^-1 R^-1 R^3 R^-1 = x^-1 R.
         let self_r_inv = nonzero_multiplicative_inverse_4(self.limbs, Self::ORDER);
-        Self {
-            limbs: Self::montgomery_multiply(self_r_inv, Self::R3),
-        }
+        Self { limbs: Self::montgomery_multiply(self_r_inv, Self::R3) }
     }
 
     fn rand() -> Self {
@@ -311,9 +229,9 @@ impl Display for Bls12377Scalar {
 
 #[cfg(test)]
 mod tests {
+    use crate::{Bls12377Scalar, Field};
     use crate::conversions::u64_slice_to_biguint;
     use crate::test_arithmetic;
-    use crate::{Bls12377Scalar, Field};
 
     #[test]
     fn bls12scalar_to_and_from_canonical() {
@@ -323,14 +241,9 @@ mod tests {
         let r_biguint = u64_slice_to_biguint(&Bls12377Scalar::R);
 
         let a_bls12scalar = Bls12377Scalar::from_canonical(a);
-        assert_eq!(
-            u64_slice_to_biguint(&a_bls12scalar.limbs),
-            &a_biguint * &r_biguint % &order_biguint
-        );
-        assert_eq!(
-            u64_slice_to_biguint(&a_bls12scalar.to_canonical()),
-            a_biguint
-        );
+        assert_eq!(u64_slice_to_biguint(&a_bls12scalar.limbs),
+                   &a_biguint * &r_biguint % &order_biguint);
+        assert_eq!(u64_slice_to_biguint(&a_bls12scalar.to_canonical()), a_biguint);
     }
 
     #[test]
@@ -347,8 +260,7 @@ mod tests {
 
         assert_eq!(
             u64_slice_to_biguint(&(a_blsbase * b_blsbase).to_canonical()),
-            a_biguint * b_biguint % order_biguint
-        );
+            a_biguint * b_biguint % order_biguint);
     }
 
     #[test]
@@ -362,22 +274,10 @@ mod tests {
 
     #[test]
     fn exp() {
-        assert_eq!(
-            Bls12377Scalar::THREE.exp(Bls12377Scalar::ZERO),
-            Bls12377Scalar::ONE
-        );
-        assert_eq!(
-            Bls12377Scalar::THREE.exp(Bls12377Scalar::ONE),
-            Bls12377Scalar::THREE
-        );
-        assert_eq!(
-            Bls12377Scalar::THREE.exp(Bls12377Scalar::from_canonical_u64(2)),
-            Bls12377Scalar::from_canonical_u64(9)
-        );
-        assert_eq!(
-            Bls12377Scalar::THREE.exp(Bls12377Scalar::from_canonical_u64(3)),
-            Bls12377Scalar::from_canonical_u64(27)
-        );
+        assert_eq!(Bls12377Scalar::THREE.exp(Bls12377Scalar::ZERO), Bls12377Scalar::ONE);
+        assert_eq!(Bls12377Scalar::THREE.exp(Bls12377Scalar::ONE), Bls12377Scalar::THREE);
+        assert_eq!(Bls12377Scalar::THREE.exp(Bls12377Scalar::from_canonical_u64(2)), Bls12377Scalar::from_canonical_u64(9));
+        assert_eq!(Bls12377Scalar::THREE.exp(Bls12377Scalar::from_canonical_u64(3)), Bls12377Scalar::from_canonical_u64(27));
     }
 
     #[test]
@@ -419,22 +319,10 @@ mod tests {
     #[test]
     fn num_bits() {
         assert_eq!(Bls12377Scalar::from_canonical_u64(0b10101).num_bits(), 5);
-        assert_eq!(
-            Bls12377Scalar::from_canonical_u64(u64::max_value()).num_bits(),
-            64
-        );
-        assert_eq!(
-            Bls12377Scalar::from_canonical([0, 1, 0, 0]).num_bits(),
-            64 + 1
-        );
-        assert_eq!(
-            Bls12377Scalar::from_canonical([0, 0, 0, 1]).num_bits(),
-            64 * 3 + 1
-        );
-        assert_eq!(
-            Bls12377Scalar::from_canonical([0, 0, 0, 0b10101]).num_bits(),
-            64 * 3 + 5
-        )
+        assert_eq!(Bls12377Scalar::from_canonical_u64(u64::max_value()).num_bits(), 64);
+        assert_eq!(Bls12377Scalar::from_canonical([0, 1, 0, 0]).num_bits(), 64 + 1);
+        assert_eq!(Bls12377Scalar::from_canonical([0, 0, 0, 1]).num_bits(), 64 * 3 + 1);
+        assert_eq!(Bls12377Scalar::from_canonical([0, 0, 0, 0b10101]).num_bits(), 64 * 3 + 5)
     }
 
     #[test]
@@ -443,16 +331,10 @@ mod tests {
             let n = 1 << n_power as u64;
             let root = Bls12377Scalar::primitive_root_of_unity(n_power);
 
-            assert_eq!(
-                root.exp(Bls12377Scalar::from_canonical_u64(n)),
-                Bls12377Scalar::ONE
-            );
+            assert_eq!(root.exp(Bls12377Scalar::from_canonical_u64(n)), Bls12377Scalar::ONE);
 
             if n > 1 {
-                assert_ne!(
-                    root.exp(Bls12377Scalar::from_canonical_u64(n - 1)),
-                    Bls12377Scalar::ONE
-                )
+                assert_ne!(root.exp(Bls12377Scalar::from_canonical_u64(n - 1)), Bls12377Scalar::ONE)
             }
         }
     }

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -140,7 +140,7 @@ pub trait Field:
         }
     }
 
-    fn is_valid_canonical_u64(v: &Vec<u64>) -> bool;
+    fn is_valid_canonical_u64(v: &[u64]) -> bool;
 
     #[inline(always)]
     fn is_zero(&self) -> bool {
@@ -493,7 +493,7 @@ pub mod field_tests {
         let modwords = ceil_div_usize(modulus.bits() as usize, word_bits);
         // Start with basic set close to zero: 0 .. 10
         const BIGGEST_SMALL: u32 = 10;
-        let smalls: Vec<_> = (0..BIGGEST_SMALL).map(|x| BigUint::from(x)).collect();
+        let smalls: Vec<_> = (0..BIGGEST_SMALL).map(BigUint::from).collect();
         // ... and close to MAX: MAX - x
         let word_max = (BigUint::one() << word_bits) - 1u32;
         let bigs = smalls.iter().map(|x| &word_max - x).collect();
@@ -516,17 +516,17 @@ pub mod field_tests {
         let diff_max = basic_inputs
             .iter()
             .map(|x| &maxval - x)
-            .filter(|x| x < &modulus)
+            .filter(|x| x < modulus)
             .collect();
         // Inputs 'difference from' modulus value
         let diff_mod = basic_inputs
             .iter()
-            .filter(|x| *x < &modulus && !x.is_zero())
+            .filter(|x| *x < modulus && !x.is_zero())
             .map(|x| modulus - x)
             .collect();
         let basics = basic_inputs
             .into_iter()
-            .filter(|x| x < &modulus)
+            .filter(|x| x < modulus)
             .collect::<Vec<BigUint>>();
         [basics, diff_max, diff_mod].concat()
 

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -11,6 +11,7 @@ use rand::Rng;
 
 use crate::{biguint_to_field, field_to_biguint, Curve, ProjectivePoint};
 
+// #[typetag::serde(tag = "type")]
 pub trait Field:
     'static
     + Sized
@@ -27,6 +28,8 @@ pub trait Field:
     + Sub<Self, Output = Self>
     + Mul<Self, Output = Self>
     + Div<Self, Output = Self>
+    + serde_traitobject::Serialize
+    + serde_traitobject::Deserialize
 {
     const BITS: usize;
     const BYTES: usize;

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -10,6 +10,7 @@ use num::{BigUint, Integer, One};
 use rand::Rng;
 
 use crate::{biguint_to_field, field_to_biguint, Curve, ProjectivePoint};
+use serde::{de::DeserializeOwned, Serialize};
 
 pub trait Field:
     'static
@@ -27,8 +28,8 @@ pub trait Field:
     + Sub<Self, Output = Self>
     + Mul<Self, Output = Self>
     + Div<Self, Output = Self>
-    + serde_traitobject::Serialize
-    + serde_traitobject::Deserialize
+    + Serialize
+    + DeserializeOwned
 {
     const BITS: usize;
     const BYTES: usize;

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -11,7 +11,6 @@ use rand::Rng;
 
 use crate::{biguint_to_field, field_to_biguint, Curve, ProjectivePoint};
 
-// #[typetag::serde(tag = "type")]
 pub trait Field:
     'static
     + Sized

--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -1,11 +1,12 @@
-pub use field::*;
 pub use bls12_377_base::*;
 pub use bls12_377_scalar::*;
+pub use field::*;
 pub use tweedledee_base::*;
 pub use tweedledum_base::*;
 
-mod field;
 mod bls12_377_base;
 mod bls12_377_scalar;
+#[allow(clippy::module_inception)]
+mod field;
 mod tweedledee_base;
 mod tweedledum_base;

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -251,7 +251,7 @@ impl Field for TweedledeeBase {
         Self::from_canonical([n, 0, 0, 0])
     }
 
-    fn is_valid_canonical_u64(v: &Vec<u64>) -> bool {
+    fn is_valid_canonical_u64(v: &[u64]) -> bool {
         v.len() == 4 && cmp_4_4(v[..].try_into().unwrap(), Self::ORDER) == Less
     }
 

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -7,12 +7,15 @@ use unroll::unroll_for_loops;
 
 use crate::nonzero_multiplicative_inverse_4;
 use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
 /// An element of the Tweedledee group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
+// #[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
+// #[typetag::serde]
 pub struct TweedledeeBase {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],
@@ -302,8 +305,8 @@ impl Debug for TweedledeeBase {
 #[cfg(test)]
 mod tests {
     use crate::test_arithmetic;
-    use crate::TweedledeeBase;
     use crate::Field;
+    use crate::TweedledeeBase;
 
     #[test]
     fn primitive_root_order() {

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -251,7 +251,7 @@ impl Field for TweedledeeBase {
         Self::from_canonical([n, 0, 0, 0])
     }
 
-    fn is_valid_canonical_u64(v: &[u64]) -> bool {
+    fn is_valid_canonical_u64(v: &Vec<u64>) -> bool {
         v.len() == 4 && cmp_4_4(v[..].try_into().unwrap(), Self::ORDER) == Less
     }
 

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -14,8 +14,6 @@ use std::fmt::{Debug, Display, Formatter};
 
 /// An element of the Tweedledee group's base field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
-// #[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
-// #[typetag::serde]
 pub struct TweedledeeBase {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -7,13 +7,12 @@ use unroll::unroll_for_loops;
 
 use crate::nonzero_multiplicative_inverse_4;
 use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
 /// An element of the Tweedledee group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub struct TweedledeeBase {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],

--- a/src/field/tweedledum_base.rs
+++ b/src/field/tweedledum_base.rs
@@ -7,10 +7,10 @@ use unroll::unroll_for_loops;
 
 use crate::nonzero_multiplicative_inverse_4;
 use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
-use serde::{Serialize, Deserialize};
 
 /// An element of the Tweedledum group's base field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
@@ -251,7 +251,7 @@ impl Field for TweedledumBase {
         Self::from_canonical([n, 0, 0, 0])
     }
 
-    fn is_valid_canonical_u64(v: &Vec<u64>) -> bool {
+    fn is_valid_canonical_u64(v: &[u64]) -> bool {
         v.len() == 4 && cmp_4_4(v[..].try_into().unwrap(), Self::ORDER) == Less
     }
 
@@ -300,12 +300,11 @@ impl Debug for TweedledumBase {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::test_arithmetic;
-    use crate::TweedledumBase;
     use crate::Field;
+    use crate::TweedledumBase;
 
     #[test]
     fn primitive_root_order() {

--- a/src/field/tweedledum_base.rs
+++ b/src/field/tweedledum_base.rs
@@ -10,9 +10,10 @@ use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_r
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
+use serde::{Serialize, Deserialize};
 
 /// An element of the Tweedledum group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
 pub struct TweedledumBase {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],

--- a/src/field/tweedledum_base.rs
+++ b/src/field/tweedledum_base.rs
@@ -7,13 +7,12 @@ use unroll::unroll_for_loops;
 
 use crate::nonzero_multiplicative_inverse_4;
 use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
 /// An element of the Tweedledum group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub struct TweedledumBase {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],

--- a/src/gates/arithmetic.rs
+++ b/src/gates/arithmetic.rs
@@ -89,7 +89,7 @@ impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for ArithmeticGate<C> {
 
     fn generate(
         &self,
-        constants: &Vec<Vec<C::ScalarField>>,
+        constants: &[Vec<C::ScalarField>],
         witness: &PartialWitness<C::ScalarField>,
     ) -> PartialWitness<C::ScalarField> {
         let multiplicand_0_target = Wire {

--- a/src/gates/base_4_sum.rs
+++ b/src/gates/base_4_sum.rs
@@ -103,7 +103,7 @@ impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for Base4SumGate<C> {
 
     fn generate(
         &self,
-        _constants: &Vec<Vec<C::ScalarField>>,
+        _constants: &[Vec<C::ScalarField>],
         _witness: &PartialWitness<C::ScalarField>,
     ) -> PartialWitness<C::ScalarField> {
         // For base 4 decompositions, we don't do any witness generation on a per-gate level.

--- a/src/gates/buffer.rs
+++ b/src/gates/buffer.rs
@@ -53,7 +53,7 @@ impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for BufferGate<C> {
 
     fn generate(
         &self,
-        _constants: &Vec<Vec<C::ScalarField>>,
+        _constants: &[Vec<C::ScalarField>],
         _witness: &PartialWitness<C::ScalarField>,
     ) -> PartialWitness<C::ScalarField> {
         PartialWitness::new()

--- a/src/gates/constant.rs
+++ b/src/gates/constant.rs
@@ -56,7 +56,7 @@ impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for ConstantGate<C> {
 
     fn generate(
         &self,
-        constants: &Vec<Vec<C::ScalarField>>,
+        constants: &[Vec<C::ScalarField>],
         _witness: &PartialWitness<C::ScalarField>,
     ) -> PartialWitness<C::ScalarField> {
         let constants = &constants[self.index];

--- a/src/gates/curve_add.rs
+++ b/src/gates/curve_add.rs
@@ -172,7 +172,7 @@ impl<C: HaloCurve, InnerC: Curve<BaseField = C::ScalarField>> WitnessGenerator<C
 
     fn generate(
         &self,
-        _constants: &Vec<Vec<C::ScalarField>>,
+        _constants: &[Vec<C::ScalarField>],
         witness: &PartialWitness<InnerC::BaseField>,
     ) -> PartialWitness<InnerC::BaseField> {
         // Notation:

--- a/src/gates/curve_dbl.rs
+++ b/src/gates/curve_dbl.rs
@@ -123,7 +123,7 @@ impl<C: HaloCurve, InnerC: Curve<BaseField = C::ScalarField>> WitnessGenerator<C
 
     fn generate(
         &self,
-        _constants: &Vec<Vec<C::ScalarField>>,
+        _constants: &[Vec<C::ScalarField>],
         witness: &PartialWitness<InnerC::BaseField>,
     ) -> PartialWitness<InnerC::BaseField> {
         let x_old_target = Wire {

--- a/src/gates/curve_endo.rs
+++ b/src/gates/curve_endo.rs
@@ -194,7 +194,7 @@ impl<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>> WitnessGenerat
 
     fn generate(
         &self,
-        _constants: &Vec<Vec<C::ScalarField>>,
+        _constants: &[Vec<C::ScalarField>],
         witness: &PartialWitness<InnerC::BaseField>,
     ) -> PartialWitness<InnerC::BaseField> {
         let group_acc_old_x_target = Wire {

--- a/src/gates/public_input.rs
+++ b/src/gates/public_input.rs
@@ -76,7 +76,7 @@ impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for PublicInputGate<C> {
 
     fn generate(
         &self,
-        _constants: &Vec<Vec<C::ScalarField>>,
+        _constants: &[Vec<C::ScalarField>],
         witness: &PartialWitness<C::ScalarField>,
     ) -> PartialWitness<C::ScalarField> {
         let self_as_generator: &dyn WitnessGenerator<C::ScalarField> = self;

--- a/src/gates/rescue_a.rs
+++ b/src/gates/rescue_a.rs
@@ -115,7 +115,7 @@ impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for RescueStepAGate<C> {
 
     fn generate(
         &self,
-        constants: &Vec<Vec<C::ScalarField>>,
+        constants: &[Vec<C::ScalarField>],
         witness: &PartialWitness<C::ScalarField>,
     ) -> PartialWitness<C::ScalarField> {
         let constants = &constants[self.index];

--- a/src/gates/rescue_b.rs
+++ b/src/gates/rescue_b.rs
@@ -106,7 +106,7 @@ impl<C: HaloCurve> WitnessGenerator<C::ScalarField> for RescueStepBGate<C> {
 
     fn generate(
         &self,
-        constants: &Vec<Vec<C::ScalarField>>,
+        constants: &[Vec<C::ScalarField>],
         witness: &PartialWitness<C::ScalarField>,
     ) -> PartialWitness<C::ScalarField> {
         let constants = &constants[self.index];

--- a/src/halo.rs
+++ b/src/halo.rs
@@ -12,6 +12,7 @@ pub struct OpeningProof<C: HaloCurve> {
     pub schnorr_proof: SchnorrProof<C>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn batch_opening_proof<C: HaloCurve>(
     polynomials_coeffs: &[&[C::ScalarField]],
     commitments: &[PolynomialCommitment<C>],
@@ -181,6 +182,7 @@ fn schnorr_protocol<C: HaloCurve>(
 }
 
 /// Verify the final IPA.
+#[allow(clippy::too_many_arguments)]
 pub fn verify_ipa<C: HaloCurve>(
     halo_l: &[AffinePoint<C>],
     halo_r: &[AffinePoint<C>],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,3 +60,6 @@ mod target;
 pub mod util;
 mod verifier;
 mod witness;
+
+#[macro_use]
+extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 // We have tons of bigint literals in Montgomery form, which won't be readable with or without underscores.
 #![allow(clippy::unreadable_literal)]
 #![feature(associated_type_bounds)]
+// This is annoying and often wrong.
+#![allow(clippy::needless_range_loop)]
 
 pub use bigint::*;
 pub use circuit_bigint::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::suspicious_arithmetic_impl)]
 // We have tons of bigint literals in Montgomery form, which won't be readable with or without underscores.
 #![allow(clippy::unreadable_literal)]
+#![feature(associated_type_bounds)]
 
 pub use bigint::*;
 pub use circuit_bigint::*;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -9,6 +9,11 @@ pub struct TargetPartitions<F: Field> {
     indices: HashMap<Target<F>, usize>,
 }
 
+impl<F: Field> Default for TargetPartitions<F> {
+    fn default() -> Self {
+        TargetPartitions::new()
+    }
+}
 impl<F: Field> TargetPartitions<F> {
     pub fn new() -> Self {
         Self {

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -568,7 +568,7 @@ impl<C: HaloCurve> Circuit<C> {
         //     self.generators.len()
         // );
 
-        println!("Witness generation took {}s", start.elapsed().as_secs_f32());
+        info!("Witness generation took {}s", start.elapsed().as_secs_f32());
         witness
     }
 

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -281,7 +281,7 @@ impl<C: HaloCurve> Circuit<C> {
         );
 
         // Get a list of all opened values, to append to the transcript.
-        let all_opening_sets: Vec<OpeningSet<C::ScalarField>> =
+        let all_opening_sets: Vec<OpeningSet<C>> =
             vec![o_local.clone(), o_right.clone(), o_below.clone()];
         let all_opened_values_sf: Vec<C::ScalarField> = all_opening_sets
             .iter()
@@ -461,7 +461,7 @@ impl<C: HaloCurve> Circuit<C> {
         old_proofs: &[OldProof<C>],
         pi_quotient_poly: &Polynomial<C::ScalarField>,
         zeta: C::ScalarField,
-    ) -> OpeningSet<C::ScalarField> {
+    ) -> OpeningSet<C> {
         let powers_of_zeta = powers(zeta, self.degree());
 
         OpeningSet {

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -117,7 +117,8 @@ impl<C: HaloCurve> Circuit<C> {
         };
 
         // Generate a random beta and gamma from the transcript.
-        challenger.observe_affine_points(&PolynomialCommitment::to_affine_vec(&c_wires));
+        challenger
+            .observe_affine_points(&PolynomialCommitment::commitments_to_affine_vec(&c_wires));
         let (beta_bf, gamma_bf) = challenger.get_2_challenges();
         let beta_sf = beta_bf.try_convert::<C::ScalarField>()?;
         let gamma_sf = gamma_bf.try_convert::<C::ScalarField>()?;
@@ -237,7 +238,8 @@ impl<C: HaloCurve> Circuit<C> {
             .collect::<Vec<_>>();
 
         // Observe the `t` polynomial commitment.
-        challenger.observe_affine_points(&PolynomialCommitment::to_affine_vec(&c_plonk_t));
+        challenger
+            .observe_affine_points(&PolynomialCommitment::commitments_to_affine_vec(&c_plonk_t));
         // If the proof doesn't output public inputs, observe the `pis_quotient` polynomial commitment and the public inputs.
         challenger.observe_affine_point(c_pis_quotient.to_affine());
         // Observe the public inputs

--- a/src/plonk_challenger.rs
+++ b/src/plonk_challenger.rs
@@ -181,6 +181,7 @@ impl<F: Field> RecursiveChallenger<F> {
         (self.get_challenge(builder), self.get_challenge(builder))
     }
 
+    #[allow(clippy::type_complexity)]
     pub(crate) fn get_3_challenges<C: HaloCurve<ScalarField = F>>(
         &mut self,
         builder: &mut CircuitBuilder<C>,

--- a/src/plonk_proof.rs
+++ b/src/plonk_proof.rs
@@ -99,9 +99,9 @@ impl<C: HaloCurve> Proof<C> {
             let r_sf = r_bf.try_convert::<C::ScalarField>()?;
             let r_bits = &r_sf.to_canonical_bool_vec()[..SECURITY_BITS];
             let u_j_squared = halo_n::<C>(r_bits);
-            let u_j = u_j_squared
-                .square_root()
-                .expect("Prover should have ensured that n(r) is square");
+            let u_j = u_j_squared.square_root().ok_or_else(|| {
+                anyhow!("Invalid transcript. Prover should have ensured that n(r) is square")
+            })?;
             halo_us.push(u_j);
         }
 

--- a/src/plonk_recursion.rs
+++ b/src/plonk_recursion.rs
@@ -220,6 +220,7 @@ pub fn recursive_verification_circuit<
 }
 
 /// Verify all IPAs in the given proof, and return IPA challenges.
+#[allow(clippy::too_many_arguments)]
 fn verify_all_ipas<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>>(
     builder: &mut CircuitBuilder<C>,
     proof: &ProofTarget<C, InnerC>,

--- a/src/plonk_util.rs
+++ b/src/plonk_util.rs
@@ -98,12 +98,10 @@ pub fn halo_n_mul<C: HaloCurve>(s_bits: &[bool], p: AffinePoint<C>) -> AffinePoi
             } else {
                 endo_p_n
             }
+        } else if bit_lo {
+            p_p
         } else {
-            if bit_lo {
-                p_p
-            } else {
-                p_n
-            }
+            p_n
         };
         acc = acc.double() + s;
     }

--- a/src/poly_commit.rs
+++ b/src/poly_commit.rs
@@ -101,7 +101,7 @@ impl<C: Curve> PolynomialCommitment<C> {
 
     /// Returns the commitment point in affine coordinates.
     /// `Self::batch_to_affine` should be run first for better performances.
-    pub fn to_affine_vec(comms: &[Self]) -> Vec<AffinePoint<C>> {
+    pub fn commitments_to_affine_vec(comms: &[Self]) -> Vec<AffinePoint<C>> {
         comms.iter().map(|c| c.to_affine()).collect()
     }
 }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::many_single_char_names)]
 use crate::{fft_precompute, fft_with_precomputation, ifft_with_precomputation_power_of_2, util::log2_ceil, AffinePoint, Curve, FftPrecomputation, Field, MsmPrecomputation, PolynomialCommitment};
 use std::cmp::Ordering;
 use std::ops::{Index, IndexMut, RangeBounds};

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -62,11 +62,11 @@ impl<C: Curve> FromBytes for AffinePoint<C> {
         let square_candidate = x.cube() + C::A * x + C::B;
         let y = square_candidate
             .square_root()
-            .ok_or(Error::new(ErrorKind::Other, "Invalid x coordinate"))?;
+            .ok_or_else(|| Error::new(ErrorKind::Other, "Invalid x coordinate"))?;
         if (y.to_canonical_u64_vec()[0] % 2) as u8 == (mask & 2) >> 1 {
-            return Ok(AffinePoint::nonzero(x, y));
+            Ok(AffinePoint::nonzero(x, y))
         } else {
-            return Ok(AffinePoint::nonzero(x, -y));
+            Ok(AffinePoint::nonzero(x, -y))
         }
     }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -113,6 +113,7 @@ impl<'de, C: Curve> Deserialize<'de> for AffinePoint<C> {
 mod test {
     use super::*;
     use crate::{blake_hash_base_field_to_curve, Bls12377, Bls12377Base, Bls12377Scalar, CircuitBuilder, HaloCurve, PartialWitness, Proof, Tweedledee, TweedledeeBase, Tweedledum, TweedledumBase, VerificationKey};
+    use anyhow::Result;
 
     macro_rules! test_field_serialization {
         ($field:ty, $test_name:ident) => {
@@ -125,8 +126,8 @@ mod test {
                 assert_eq!(x, y);
 
                 // Serde (de)serialization
-                let ser = bincode::serialize(&x).unwrap();
-                let y = bincode::deserialize(&ser).unwrap();
+                let ser = bincode::serialize(&x)?;
+                let y = bincode::deserialize(&ser)?;
                 assert_eq!(x, y);
 
                 Ok(())
@@ -157,11 +158,11 @@ mod test {
                 assert_eq!(zero, q);
 
                 // Serde (de)serialization
-                let ser = bincode::serialize(&p).unwrap();
-                let q = bincode::deserialize(&ser).unwrap();
+                let ser = bincode::serialize(&p)?;
+                let q = bincode::deserialize(&ser)?;
                 assert_eq!(p, q);
-                let ser = bincode::serialize(&zero).unwrap();
-                let q = bincode::deserialize(&ser).unwrap();
+                let ser = bincode::serialize(&zero)?;
+                let q = bincode::deserialize(&ser)?;
                 assert_eq!(zero, q);
 
                 Ok(())

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -178,6 +178,7 @@ pub fn verify_proof<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField>>
 }
 
 /// Verify all IPAs in the given proof using a reduction to a single polynomial.
+#[allow(clippy::too_many_arguments)]
 fn verify_all_ipas<C: HaloCurve>(
     c_constants: &[AffinePoint<C>],
     c_s_sigmas: &[AffinePoint<C>],
@@ -372,9 +373,7 @@ fn public_inputs_to_polynomial<F: Field>(
                 .fold(F::ZERO, |acc, x| acc + x)
         })
         .collect::<Vec<_>>();
-    for _ in scaled_wires_vec.len()..degree {
-        scaled_wires_vec.push(F::ZERO);
-    }
+    scaled_wires_vec.resize(degree, F::ZERO);
 
     fft_precomputation.map_or_else(
         || Polynomial::from_evaluations(&scaled_wires_vec, &fft_precompute(degree)),

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, ensure, Result};
+use serde::{Deserialize, Serialize};
 
 use crate::partition::get_subgroup_shift;
 
@@ -11,14 +12,16 @@ use crate::{blake_hash_usize_to_curve, fft_precompute, msm_execute_parallel, msm
 
 pub const SECURITY_BITS: usize = 128;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerificationKey<C: HaloCurve> {
     pub c_constants: Vec<AffinePoint<C>>,
     pub c_s_sigmas: Vec<AffinePoint<C>>,
     pub degree: usize,
     pub num_public_inputs: usize,
     pub security_bits: usize,
+    #[serde(skip)]
     pub pedersen_g_msm_precomputation: Option<MsmPrecomputation<C>>,
+    #[serde(skip)]
     pub fft_precomputation: Option<FftPrecomputation<C::ScalarField>>,
 }
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -7,6 +7,11 @@ pub struct PartialWitness<F: Field> {
     wire_values: HashMap<Target<F>, F>,
 }
 
+impl<F: Field> Default for PartialWitness<F> {
+    fn default() -> Self {
+        PartialWitness::new()
+    }
+}
 impl<F: Field> PartialWitness<F> {
     pub fn new() -> Self {
         PartialWitness {
@@ -82,7 +87,7 @@ impl<F: Field> PartialWitness<F> {
         let mut result = BigUint::zero();
         for (i, &limb) in target.limbs.iter().enumerate() {
             let limb_value = field_to_biguint(self.get_target(limb));
-            result += limb_value << i * LIMB_BITS;
+            result += limb_value << (i * LIMB_BITS);
         }
         result
     }
@@ -222,5 +227,5 @@ pub trait WitnessGenerator<F: Field>: 'static + Sync {
     fn dependencies(&self) -> Vec<Target<F>>;
 
     /// Given a partial witness, return any newly generated values. The caller will merge them in.
-    fn generate(&self, constants: &Vec<Vec<F>>, witness: &PartialWitness<F>) -> PartialWitness<F>;
+    fn generate(&self, constants: &[Vec<F>], witness: &PartialWitness<F>) -> PartialWitness<F>;
 }

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use plonky::{blake_hash_base_field_to_curve, msm_parallel, rescue_hash_1_to_1, verify_proof, AffinePoint, Base4SumGate, Circuit, CircuitBuilder, Curve, CurveMulOp, Field, HaloCurve, PartialWitness, Target, Tweedledee, Tweedledum, Wire, Witness};
 use rand::{thread_rng, Rng};
 use std::time::Instant;
-use bincode;
 
 fn get_trivial_circuit<C: HaloCurve>(x: C::ScalarField) -> (Circuit<C>, Witness<C::ScalarField>) {
     let mut builder = CircuitBuilder::<C>::new(128);
@@ -150,9 +149,13 @@ fn test_proof_quadratic_public_input() -> Result<()> {
         .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let vk = circuit.to_vk();
-    let vks = bincode::serialize(&vk).unwrap();
-    dbg!(vks);
-    verify_proof::<Tweedledee, Tweedledum>(&[F::from_canonical_usize(7)], &proof, &[], &vk, true)?;
+    verify_proof::<Tweedledee, Tweedledum>(
+        &[F::from_canonical_usize(7)],
+        &proof,
+        &[],
+        &vk,
+        false,
+    )?;
 
     Ok(())
 }
@@ -200,7 +203,7 @@ fn test_proof_factorial_public_input() -> Result<()> {
     type F = <Tweedledee as Curve>::ScalarField;
     let mut builder = CircuitBuilder::<Tweedledee>::new(128);
     let n = 20;
-    let factorial_usize = (1..=n).fold(1, |acc, i| acc * i);
+    let factorial_usize = (1..=n).product();
     let factors_pis = builder.stage_public_inputs(n);
     builder.route_public_inputs();
     let res = builder.constant_wire(F::from_canonical_usize(factorial_usize));

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -1,5 +1,9 @@
 use anyhow::Result;
-use plonky::{blake_hash_base_field_to_curve, msm_parallel, rescue_hash_1_to_1, verify_proof, AffinePoint, Base4SumGate, Circuit, CircuitBuilder, Curve, CurveMulOp, Field, HaloCurve, PartialWitness, Target, Tweedledee, Tweedledum, Wire, Witness};
+use plonky::{
+    blake_hash_base_field_to_curve, msm_parallel, rescue_hash_1_to_1, verify_proof, AffinePoint,
+    Base4SumGate, Circuit, CircuitBuilder, Curve, CurveMulOp, Field, HaloCurve, PartialWitness,
+    Target, Tweedledee, Tweedledum, Wire, Witness,
+};
 use rand::{thread_rng, Rng};
 use std::time::Instant;
 
@@ -26,6 +30,7 @@ fn test_proof_trivial() -> Result<()> {
 }
 
 #[test]
+#[allow(clippy::same_item_push)]
 fn test_proof_trivial_circuit_many_proofs() -> Result<()> {
     let mut old_proofs = Vec::new();
     for _ in 0..10 {
@@ -149,13 +154,7 @@ fn test_proof_quadratic_public_input() -> Result<()> {
         .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let vk = circuit.to_vk();
-    verify_proof::<Tweedledee, Tweedledum>(
-        &[F::from_canonical_usize(7)],
-        &proof,
-        &[],
-        &vk,
-        false,
-    )?;
+    verify_proof::<Tweedledee, Tweedledum>(&[F::from_canonical_usize(7)], &proof, &[], &vk, false)?;
 
     Ok(())
 }

--- a/tests/prove_and_verify.rs
+++ b/tests/prove_and_verify.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use plonky::{blake_hash_base_field_to_curve, msm_parallel, rescue_hash_1_to_1, verify_proof, AffinePoint, Base4SumGate, Circuit, CircuitBuilder, Curve, CurveMulOp, Field, HaloCurve, PartialWitness, Target, Tweedledee, Tweedledum, Wire, Witness};
 use rand::{thread_rng, Rng};
 use std::time::Instant;
+use bincode;
 
 fn get_trivial_circuit<C: HaloCurve>(x: C::ScalarField) -> (Circuit<C>, Witness<C::ScalarField>) {
     let mut builder = CircuitBuilder::<C>::new(128);
@@ -149,6 +150,8 @@ fn test_proof_quadratic_public_input() -> Result<()> {
         .generate_proof::<Tweedledum>(&witness, &[], true)
         .unwrap();
     let vk = circuit.to_vk();
+    let vks = bincode::serialize(&vk).unwrap();
+    dbg!(vks);
     verify_proof::<Tweedledee, Tweedledum>(&[F::from_canonical_usize(7)], &proof, &[], &vk, true)?;
 
     Ok(())


### PR DESCRIPTION
This PR adds serialization for the `Proof` and `VerificationKey` structs using Serde's `(De)Serialization` traits. 
It also adds basic logging using the [pretty-env-logger](https://github.com/seanmonstar/pretty-env-logger) crate.
Finally I've cleaned up all Clippy lints.