### PR TITLE
Prevent Serde from adding redundant bounds on `F`

### DIFF
--- a/src/field/bls12_377_base.rs
+++ b/src/field/bls12_377_base.rs
@@ -9,13 +9,12 @@ use unroll::unroll_for_loops;
 
 use crate::{add_6_6_no_overflow, cmp_6_6, Field, mul2_6, rand_range_6, rand_range_6_from_rng, sub_6_6, field_to_biguint};
 use crate::nonzero_multiplicative_inverse_6;
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::{Formatter, Display};
 use std::fmt;
 
 /// An element of the BLS12 group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Bls12377Base {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 6],

--- a/src/field/bls12_377_scalar.rs
+++ b/src/field/bls12_377_scalar.rs
@@ -9,13 +9,12 @@ use unroll::unroll_for_loops;
 
 use crate::{add_4_4_no_overflow, cmp_4_4, Field, sub_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng};
 use crate::nonzero_multiplicative_inverse_4;
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
 /// An element of the BLS12 group's scalar field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Bls12377Scalar {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -251,7 +251,7 @@ impl Field for TweedledeeBase {
         Self::from_canonical([n, 0, 0, 0])
     }
 
-    fn is_valid_canonical_u64(v: &Vec<u64>) -> bool {
+    fn is_valid_canonical_u64(v: &[u64]) -> bool {
         v.len() == 4 && cmp_4_4(v[..].try_into().unwrap(), Self::ORDER) == Less
     }
 

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -7,13 +7,12 @@ use unroll::unroll_for_loops;
 
 use crate::nonzero_multiplicative_inverse_4;
 use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
 /// An element of the Tweedledee group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub struct TweedledeeBase {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],

--- a/src/field/tweedledum_base.rs
+++ b/src/field/tweedledum_base.rs
@@ -7,13 +7,12 @@ use unroll::unroll_for_loops;
 
 use crate::nonzero_multiplicative_inverse_4;
 use crate::{add_4_4_no_overflow, cmp_4_4, field_to_biguint, rand_range_4, rand_range_4_from_rng, sub_4_4, Field};
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
 /// An element of the Tweedledum group's base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub struct TweedledumBase {
     /// Montgomery representation, encoded with little-endian u64 limbs.
     pub limbs: [u64; 4],

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -283,7 +283,7 @@ impl<C: HaloCurve> Circuit<C> {
         );
 
         // Get a list of all opened values, to append to the transcript.
-        let all_opening_sets: Vec<OpeningSet<C>> =
+        let all_opening_sets: Vec<OpeningSet<C::ScalarField>> =
             vec![o_local.clone(), o_right.clone(), o_below.clone()];
         let all_opened_values_sf: Vec<C::ScalarField> = all_opening_sets
             .iter()
@@ -463,7 +463,7 @@ impl<C: HaloCurve> Circuit<C> {
         old_proofs: &[OldProof<C>],
         pi_quotient_poly: &Polynomial<C::ScalarField>,
         zeta: C::ScalarField,
-    ) -> OpeningSet<C> {
+    ) -> OpeningSet<C::ScalarField> {
         let powers_of_zeta = powers(zeta, self.degree());
 
         OpeningSet {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -113,6 +113,7 @@ impl<'de, C: Curve> Deserialize<'de> for AffinePoint<C> {
 mod test {
     use super::*;
     use crate::{blake_hash_base_field_to_curve, Bls12377, Bls12377Base, Bls12377Scalar, CircuitBuilder, HaloCurve, PartialWitness, Proof, Tweedledee, TweedledeeBase, Tweedledum, TweedledumBase, VerificationKey};
+    use anyhow::Result;
 
     macro_rules! test_field_serialization {
         ($field:ty, $test_name:ident) => {
@@ -125,8 +126,8 @@ mod test {
                 assert_eq!(x, y);
 
                 // Serde (de)serialization
-                let ser = bincode::serialize(&x).unwrap();
-                let y = bincode::deserialize(&ser).unwrap();
+                let ser = bincode::serialize(&x)?;
+                let y = bincode::deserialize(&ser)?;
                 assert_eq!(x, y);
 
                 Ok(())
@@ -157,11 +158,11 @@ mod test {
                 assert_eq!(zero, q);
 
                 // Serde (de)serialization
-                let ser = bincode::serialize(&p).unwrap();
-                let q = bincode::deserialize(&ser).unwrap();
+                let ser = bincode::serialize(&p)?;
+                let q = bincode::deserialize(&ser)?;
                 assert_eq!(p, q);
-                let ser = bincode::serialize(&zero).unwrap();
-                let q = bincode::deserialize(&ser).unwrap();
+                let ser = bincode::serialize(&zero)?;
+                let q = bincode::deserialize(&ser)?;
                 assert_eq!(zero, q);
 
                 Ok(())


### PR DESCRIPTION
Since `Field` is already a subtrait of `Serialize` and `DeserializeOwned`, we don't need Serde to add its own bounds like `where F: Serialize`. The redundant bounds would normally be harmless, but they cause an error due to a compiler bug: https://github.com/rust-lang/rust/issues/41617