### PR TITLE
Move public inputs to the end of circuits

### DIFF
--- a/src/bin/recursion.rs
+++ b/src/bin/recursion.rs
@@ -99,7 +99,6 @@ fn main() -> Result<()> {
 
 fn generate_trivial_circuit() -> Circuit<Tweedledum> {
     let mut builder = CircuitBuilder::new(SECURITY_BITS);
-    builder.route_public_inputs();
     while builder.num_gates() < INNER_PROOF_DEGREE - 3 {
         builder.add_gate_no_constants(BufferGate::new(builder.num_gates()));
     }

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -7,7 +7,6 @@ use crate::plonk_util::{commit_polynomials, polynomials_to_values_padded, sigma_
 use crate::util::{ceil_div_usize, log2_strict, transpose};
 use crate::{blake_hash_usize_to_curve, fft_precompute, generate_rescue_constants, msm_precompute, AffinePoint, AffinePointTarget, BoundedTarget, Circuit, Curve, Field, HaloCurve, PartialWitness, PublicInput, Target, TargetPartitions, VirtualTarget, Wire, WitnessGenerator, NUM_CONSTANTS, NUM_WIRES};
 use num::{BigUint, Zero};
-use std::marker::PhantomData;
 
 pub struct CircuitBuilder<C: HaloCurve> {
     pub(crate) security_bits: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 // Required for generic low-level functions on small arrays.
 #![feature(const_generics)]
-// Unfortunatly it makes rustc complain, so we include
+// Unfortunately it makes rustc complain, so we include
 #![allow(incomplete_features)]
 
 

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -31,6 +31,7 @@ pub(crate) const QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER: usize = 7;
 pub struct Circuit<C: HaloCurve> {
     pub security_bits: usize,
     pub num_public_inputs: usize,
+    pub num_gates_without_pis: usize,
     pub gate_constants: Vec<Vec<C::ScalarField>>,
     pub routing_target_partitions: TargetPartitions<C::ScalarField>,
     pub generators: Vec<Box<dyn WitnessGenerator<C::ScalarField>>>,
@@ -110,7 +111,7 @@ impl<C: HaloCurve> Circuit<C> {
             wire_values_by_wire_no_pis.iter_mut().for_each(|w| {
                 for i in 0..num_public_input_gates {
                     // Set the wire value at the public input gate to zero.
-                    w[2 * i] = C::ScalarField::ZERO;
+                    w[self.num_gates_without_pis + 2 * i] = C::ScalarField::ZERO;
                 }
             });
             values_to_polynomials(&wire_values_by_wire_no_pis, &self.fft_precomputation_n)
@@ -207,7 +208,7 @@ impl<C: HaloCurve> Circuit<C> {
                 Polynomial::from(vec![C::ScalarField::ONE]),
                 |acc, i| {
                     let mut ans =
-                        acc.mul(&vec![-self.subgroup_n[2 * i], C::ScalarField::ONE].into());
+                        acc.mul(&vec![-self.subgroup_n[self.num_gates_without_pis + 2 * i], C::ScalarField::ONE].into());
                     ans.trim();
                     ans
                 },
@@ -234,7 +235,7 @@ impl<C: HaloCurve> Circuit<C> {
         );
 
         let public_inputs = (0..self.num_public_inputs)
-            .map(|i| wire_values_by_wire_index[i % NUM_WIRES][2 * (i / NUM_WIRES)])
+            .map(|i| wire_values_by_wire_index[i % NUM_WIRES][self.num_gates_without_pis + 2 * (i / NUM_WIRES)])
             .collect::<Vec<_>>();
 
         // Observe the `t` polynomial commitment.
@@ -503,6 +504,10 @@ impl<C: HaloCurve> Circuit<C> {
 
         // We start with the inputs as our witness, and execute any copy constraints.
         let mut witness = inputs;
+
+        // Replace public inputs targets by their corresponding wires in the circuit.
+        witness.replace_public_inputs(self.num_gates_without_pis);
+        
         witness.extend(self.generate_copies(&witness, &witness.all_populated_targets()));
 
         // Build a list of "pending" generators which are ready to run.
@@ -621,6 +626,7 @@ impl<C: HaloCurve> Circuit<C> {
                 .collect::<Vec<_>>(),
             degree: self.degree(),
             num_public_inputs: self.num_public_inputs,
+            num_gates_without_pis: self.num_gates_without_pis,
             security_bits: self.security_bits,
             pedersen_g_msm_precomputation: Some(self.pedersen_g_msm_precomputation.clone()),
             fft_precomputation: Some(self.fft_precomputation_n.clone()),
@@ -629,7 +635,7 @@ impl<C: HaloCurve> Circuit<C> {
 
     pub fn get_public_inputs(&self, witness: &Witness<C::ScalarField>) -> Vec<C::ScalarField> {
         (0..self.num_public_inputs)
-            .map(|i| witness.get_indices(2 * (i / NUM_WIRES), i % NUM_WIRES))
+            .map(|i| witness.get_indices(self.num_gates_without_pis + 2 * (i / NUM_WIRES), i % NUM_WIRES))
             .collect()
     }
 }

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -507,8 +507,10 @@ impl<C: HaloCurve> Circuit<C> {
 
         // Replace public inputs targets by their corresponding wires in the circuit.
         witness.replace_public_inputs(self.num_gates_without_pis);
-        
-        witness.extend(self.generate_copies(&witness, &witness.all_populated_targets()));
+
+        let mut copy_result = self.generate_copies(&witness, &witness.all_populated_targets());
+        copy_result.copy_buffer_to_pi_gate(self.num_gates_without_pis);
+        witness.extend(copy_result);
 
         // Build a list of "pending" generators which are ready to run.
         let mut pending_generator_indices = HashSet::new();
@@ -539,7 +541,8 @@ impl<C: HaloCurve> Circuit<C> {
                 completed_generator_indices.insert(generator_idx);
             }
 
-            let copy_result = self.generate_copies(&witness, &populated_targets);
+            let mut copy_result = self.generate_copies(&witness, &populated_targets);
+            copy_result.copy_buffer_to_pi_gate(self.num_gates_without_pis);
             populated_targets.extend(copy_result.all_populated_targets());
             witness.extend(copy_result);
 

--- a/src/plonk_recursion.rs
+++ b/src/plonk_recursion.rs
@@ -3,7 +3,7 @@ use crate::plonk_challenger::RecursiveChallenger;
 use crate::plonk_proof::OldProofTarget;
 use crate::plonk_util::{powers_recursive, reduce_with_powers_recursive};
 use crate::util::ceil_div_usize;
-use crate::{get_subgroup_shift, hash_usize_to_curve, AffinePointTarget, Circuit, CircuitBuilder, CurveMulEndoResult, CurveMulOp, Field, HaloCurve, OpeningSetTarget, ProofTarget, PublicInput, SchnorrProofTarget, Target, GRID_WIDTH, NUM_CONSTANTS, NUM_ROUTED_WIRES, NUM_WIRES, QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER};
+use crate::{get_subgroup_shift, hash_usize_to_curve, AffinePointTarget, Circuit, CircuitBuilder, CurveMulEndoResult, CurveMulOp, Field, HaloCurve, OpeningSetTarget, ProofTarget, SchnorrProofTarget, Target, GRID_WIDTH, NUM_CONSTANTS, NUM_ROUTED_WIRES, NUM_WIRES, QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER};
 
 /// Wraps a `Circuit` for recursive verification with inputs for the proof data.
 /// The circuit is over the field `C::ScalarField` and verifies a proof performed over the curve `InnerC`.

--- a/src/plonk_recursion.rs
+++ b/src/plonk_recursion.rs
@@ -17,20 +17,20 @@ pub struct RecursiveCircuit<C: HaloCurve, InnerC: HaloCurve<BaseField = C::Scala
 /// Public inputs of the recursive circuit. This contains data for the inner proof which is needed
 /// to complete verification of it.
 pub struct RecursionPublicInputs<F: Field> {
-    beta: PublicInput<F>,
-    gamma: PublicInput<F>,
-    alpha: PublicInput<F>,
-    zeta: PublicInput<F>,
-    o_constants: Vec<PublicInput<F>>,
-    o_plonk_sigmas: Vec<PublicInput<F>>,
-    o_local_wires: Vec<PublicInput<F>>,
-    o_right_wires: Vec<PublicInput<F>>,
-    o_below_wires: Vec<PublicInput<F>>,
-    o_plonk_z_local: PublicInput<F>,
-    o_plonk_z_right: PublicInput<F>,
-    o_plonk_t: Vec<PublicInput<F>>,
-    halo_us: Vec<PublicInput<F>>,
-    old_proofs: Vec<PublicInput<F>>,
+    beta: Target<F>,
+    gamma: Target<F>,
+    alpha: Target<F>,
+    zeta: Target<F>,
+    o_constants: Vec<Target<F>>,
+    o_plonk_sigmas: Vec<Target<F>>,
+    o_local_wires: Vec<Target<F>>,
+    o_right_wires: Vec<Target<F>>,
+    o_below_wires: Vec<Target<F>>,
+    o_plonk_z_local: Target<F>,
+    o_plonk_z_right: Target<F>,
+    o_plonk_t: Vec<Target<F>>,
+    halo_us: Vec<Target<F>>,
+    old_proofs: Vec<Target<F>>,
 }
 
 /// The number of `PublicInputGate`s needed to route the given number of public inputs.
@@ -49,25 +49,23 @@ pub fn recursive_verification_circuit<
 ) -> RecursiveCircuit<C, InnerC> {
     let mut builder = CircuitBuilder::<C>::new(security_bits);
     let public_inputs = RecursionPublicInputs {
-        beta: builder.stage_public_input(),
-        gamma: builder.stage_public_input(),
-        alpha: builder.stage_public_input(),
-        zeta: builder.stage_public_input(),
-        o_constants: builder.stage_public_inputs(NUM_CONSTANTS),
-        o_plonk_sigmas: builder.stage_public_inputs(NUM_ROUTED_WIRES),
-        o_local_wires: builder.stage_public_inputs(NUM_WIRES),
-        o_right_wires: builder.stage_public_inputs(NUM_WIRES),
-        o_below_wires: builder.stage_public_inputs(NUM_WIRES),
-        o_plonk_z_local: builder.stage_public_input(),
-        o_plonk_z_right: builder.stage_public_input(),
-        o_plonk_t: builder.stage_public_inputs(QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER),
-        halo_us: builder.stage_public_inputs(degree_pow),
-        old_proofs: builder.stage_public_inputs((2 + degree_pow) * num_old_proofs),
+        beta: builder.add_public_input(),
+        gamma: builder.add_public_input(),
+        alpha: builder.add_public_input(),
+        zeta: builder.add_public_input(),
+        o_constants: builder.add_public_inputs(NUM_CONSTANTS),
+        o_plonk_sigmas: builder.add_public_inputs(NUM_ROUTED_WIRES),
+        o_local_wires: builder.add_public_inputs(NUM_WIRES),
+        o_right_wires: builder.add_public_inputs(NUM_WIRES),
+        o_below_wires: builder.add_public_inputs(NUM_WIRES),
+        o_plonk_z_local: builder.add_public_input(),
+        o_plonk_z_right: builder.add_public_input(),
+        o_plonk_t: builder.add_public_inputs(QUOTIENT_POLYNOMIAL_DEGREE_MULTIPLIER),
+        halo_us: builder.add_public_inputs(degree_pow),
+        old_proofs: builder.add_public_inputs((2 + degree_pow) * num_old_proofs),
     };
 
     let num_public_input_gates = num_public_input_gates(num_public_inputs);
-
-    builder.route_public_inputs();
 
     let proof = ProofTarget::<C, InnerC> {
         c_wires: builder.add_virtual_point_targets(NUM_WIRES),
@@ -151,61 +149,61 @@ pub fn recursive_verification_circuit<
     );
 
     // "Outputs" data relating to assumption which still need to be verified by the next proof.
-    builder.copy(public_inputs.beta.routable_target(), beta);
-    builder.copy(public_inputs.gamma.routable_target(), gamma);
-    builder.copy(public_inputs.alpha.routable_target(), alpha);
-    builder.copy(public_inputs.zeta.routable_target(), zeta);
+    builder.copy(public_inputs.beta, beta);
+    builder.copy(public_inputs.gamma, gamma);
+    builder.copy(public_inputs.alpha, alpha);
+    builder.copy(public_inputs.zeta, zeta);
     for i in 0..NUM_CONSTANTS {
         builder.copy(
-            public_inputs.o_constants[i].routable_target(),
+            public_inputs.o_constants[i],
             proof.o_local.o_constants[i],
         );
     }
     for i in 0..NUM_ROUTED_WIRES {
         builder.copy(
-            public_inputs.o_plonk_sigmas[i].routable_target(),
+            public_inputs.o_plonk_sigmas[i],
             proof.o_local.o_plonk_sigmas[i],
         );
     }
     for i in 0..NUM_WIRES {
         builder.copy(
-            public_inputs.o_local_wires[i].routable_target(),
+            public_inputs.o_local_wires[i],
             proof.o_local.o_wires[i],
         );
         builder.copy(
-            public_inputs.o_right_wires[i].routable_target(),
+            public_inputs.o_right_wires[i],
             proof.o_right.o_wires[i],
         );
         builder.copy(
-            public_inputs.o_below_wires[i].routable_target(),
+            public_inputs.o_below_wires[i],
             proof.o_below.o_wires[i],
         );
     }
     builder.copy(
-        public_inputs.o_plonk_z_local.routable_target(),
+        public_inputs.o_plonk_z_local,
         proof.o_local.o_plonk_z,
     );
     builder.copy(
-        public_inputs.o_plonk_z_right.routable_target(),
+        public_inputs.o_plonk_z_right,
         proof.o_right.o_plonk_z,
     );
     for i in 0..degree_pow {
-        builder.copy(public_inputs.halo_us[i].routable_target(), halo_us[i]);
+        builder.copy(public_inputs.halo_us[i], halo_us[i]);
     }
     let shift = 2 + degree_pow;
     for i in 0..num_old_proofs {
         builder.copy(
             old_proofs[i].halo_g.x,
-            public_inputs.old_proofs[shift * i].routable_target(),
+            public_inputs.old_proofs[shift * i],
         );
         builder.copy(
             old_proofs[i].halo_g.y,
-            public_inputs.old_proofs[shift * i + 1].routable_target(),
+            public_inputs.old_proofs[shift * i + 1],
         );
         for j in 0..degree_pow {
             builder.copy(
                 old_proofs[i].halo_us[j].convert(),
-                public_inputs.old_proofs[shift * i + j + 2].routable_target(),
+                public_inputs.old_proofs[shift * i + j + 2],
             );
         }
     }
@@ -480,34 +478,34 @@ fn verify_assumptions<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField
     let o_constants: Vec<Target<C::ScalarField>> = public_inputs
         .o_constants
         .iter()
-        .map(|pi| o_public_inputs[pi.index])
+        .map(|pi| o_public_inputs[pi.index()])
         .collect();
     let o_sigmas: Vec<Target<C::ScalarField>> = public_inputs
         .o_plonk_sigmas
         .iter()
-        .map(|pi| o_public_inputs[pi.index])
+        .map(|pi| o_public_inputs[pi.index()])
         .collect();
     let o_local_wires: Vec<Target<C::ScalarField>> = public_inputs
         .o_local_wires
         .iter()
-        .map(|pi| o_public_inputs[pi.index])
+        .map(|pi| o_public_inputs[pi.index()])
         .collect();
     let o_right_wires: Vec<Target<C::ScalarField>> = public_inputs
         .o_right_wires
         .iter()
-        .map(|pi| o_public_inputs[pi.index])
+        .map(|pi| o_public_inputs[pi.index()])
         .collect();
     let o_below_wires: Vec<Target<C::ScalarField>> = public_inputs
         .o_below_wires
         .iter()
-        .map(|pi| o_public_inputs[pi.index])
+        .map(|pi| o_public_inputs[pi.index()])
         .collect();
-    let beta = o_public_inputs[public_inputs.beta.index];
-    let gamma = o_public_inputs[public_inputs.gamma.index];
-    let alpha = o_public_inputs[public_inputs.alpha.index];
-    let zeta = o_public_inputs[public_inputs.zeta.index];
-    let o_z_local = o_public_inputs[public_inputs.o_plonk_z_local.index];
-    let o_z_right = o_public_inputs[public_inputs.o_plonk_z_right.index];
+    let beta = o_public_inputs[public_inputs.beta.index()];
+    let gamma = o_public_inputs[public_inputs.gamma.index()];
+    let alpha = o_public_inputs[public_inputs.alpha.index()];
+    let zeta = o_public_inputs[public_inputs.zeta.index()];
+    let o_z_local = o_public_inputs[public_inputs.o_plonk_z_local.index()];
+    let o_z_right = o_public_inputs[public_inputs.o_plonk_z_right.index()];
 
     // Evaluate zeta^degree.
     let mut zeta_power_d = zeta;
@@ -564,7 +562,7 @@ fn verify_assumptions<C: HaloCurve, InnerC: HaloCurve<BaseField = C::ScalarField
     let t_components: Vec<Target<C::ScalarField>> = public_inputs
         .o_plonk_t
         .iter()
-        .map(|pi| o_public_inputs[pi.index])
+        .map(|pi| o_public_inputs[pi.index()])
         .collect();
     let o_plonk_t_eval = eval_composite_poly(builder, &t_components, zeta_power_d);
     builder.copy(quotient_eval, o_plonk_t_eval);

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -238,18 +238,17 @@ mod test {
         let mut builder = CircuitBuilder::<C>::new(128);
         let n = 10;
         let factorial_usize = (1..=n).product();
-        let factors_pis = builder.stage_public_inputs(n);
-        builder.route_public_inputs();
+        let factors_pis = builder.add_public_inputs(n);
         let res = builder.constant_wire(C::ScalarField::from_canonical_usize(factorial_usize));
         let mut factorial = builder.one_wire();
-        factors_pis.iter().for_each(|pi| {
-            factorial = builder.mul(factorial, pi.routable_target());
+        factors_pis.iter().for_each(|&pi| {
+            factorial = builder.mul(factorial, pi);
         });
         builder.copy(factorial, res);
         let mut partial_witness = PartialWitness::new();
         (0..n).for_each(|i| {
             partial_witness
-                .set_public_input(factors_pis[i], C::ScalarField::from_canonical_usize(i + 1));
+                .set_target(factors_pis[i], C::ScalarField::from_canonical_usize(i + 1));
         });
         let circuit = builder.build();
         let witness = circuit.generate_witness(partial_witness);

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -1,5 +1,5 @@
 use crate::util::transpose;
-use crate::{biguint_to_field, biguint_to_limbs, field_to_biguint, AffinePoint, AffinePointTarget, BigIntTarget, Curve, Field, ForeignFieldTarget, OrderingTarget, Target, Wire, LIMB_BITS, NUM_WIRES};
+use crate::{biguint_to_field, biguint_to_limbs, field_to_biguint, AffinePoint, AffinePointTarget, BigIntTarget, Curve, Field, ForeignFieldTarget, OrderingTarget, Target, Wire, LIMB_BITS, NUM_WIRES, NUM_ADVICE_WIRES, NUM_ROUTED_WIRES};
 use num::{BigUint, Zero};
 use std::{cmp::Ordering, collections::HashMap};
 
@@ -13,6 +13,7 @@ impl<F: Field> Default for PartialWitness<F> {
         PartialWitness::new()
     }
 }
+
 impl<F: Field> PartialWitness<F> {
     pub fn new() -> Self {
         PartialWitness {
@@ -174,10 +175,9 @@ impl<F: Field> PartialWitness<F> {
         }
     }
 
-    #[allow(clippy::needless_collect)]
-    // Replace all `PublicInput`-type targets by their corresponding `Wire`-type targets
-    // in the partial witness.
-    pub fn replace_public_inputs(&mut self, offset: usize) {
+    /// Replace all `PublicInput`-type targets by their corresponding `Wire`-type targets
+    /// in the partial witness.
+    pub(crate) fn replace_public_inputs(&mut self, offset: usize) {
         let new_pis = self.wire_values.iter().filter_map(|(t, v)| {
             if let Target::PublicInput(pi) = t {
                 Some((Target::Wire(pi.original_wire(offset)), *v))
@@ -187,10 +187,22 @@ impl<F: Field> PartialWitness<F> {
         }).collect::<Vec<_>>();
 
         self.wire_values.retain(|t, _| !matches!(t, Target::PublicInput(_)));
+        self.wire_values.extend(new_pis);
+    }
 
-        for (t, v) in new_pis.into_iter() {
-            self.wire_values.insert(t, v);
-        }
+    /// Looks through the keys and looks for targets in `BufferGate`s following a `PublicInputGate`.
+    /// If some are found, add the corresponding non-routable wire in the `PublicInputGate` to the
+    /// partial witness.
+    pub(crate) fn copy_buffer_to_pi_gate(&mut self, offset: usize) {
+        let pis_wires = self.wire_values.iter().filter_map(|(t, &v)| {
+            match t {
+                Target::Wire(Wire { gate: n, input: i }) if ((*n > offset) && ((n - offset) % 2 == 1) && (*i < NUM_ADVICE_WIRES)) => {
+                    Some((Target::Wire(Wire { gate: n - 1, input: NUM_ROUTED_WIRES + i }), v))
+                }
+                _ => None
+            }
+        }).collect::<Vec<_>>();
+        self.wire_values.extend(pis_wires);
     }
 }
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -1,5 +1,5 @@
 use crate::util::transpose;
-use crate::{biguint_to_field, biguint_to_limbs, field_to_biguint, AffinePoint, AffinePointTarget, BigIntTarget, Curve, Field, ForeignFieldTarget, OrderingTarget, PublicInput, Target, Wire, LIMB_BITS, NUM_WIRES};
+use crate::{biguint_to_field, biguint_to_limbs, field_to_biguint, AffinePoint, AffinePointTarget, BigIntTarget, Curve, Field, ForeignFieldTarget, OrderingTarget, Target, Wire, LIMB_BITS, NUM_WIRES};
 use num::{BigUint, Zero};
 use std::{cmp::Ordering, collections::HashMap};
 


### PR DESCRIPTION
I've implemented the functionalities to put the public inputs at the end of the circuits and not at the beginning as it is now.
I haven't modified `plonk_recursion.rs` except to make it compile.   