### PR TITLE
Curve: double improvement

### DIFF
--- a/benches/bls12_g1.rs
+++ b/benches/bls12_g1.rs
@@ -32,6 +32,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         black_box(p1_projective).double()
     }));
 
+    c.bench_function("BLS12 G1 affine doubling", move |b| b.iter(|| {
+        black_box(p1_affine).double()
+    }));
+
     c.bench_function("BLS12 G1 projective multiplication", move |b| b.iter(|| {
         black_box(Bls12377::convert(s)) * black_box(p1_projective)
     }));

--- a/src/curve/bls12_377_curve.rs
+++ b/src/curve/bls12_377_curve.rs
@@ -37,6 +37,17 @@ mod tests {
     use crate::{Bls12377, Bls12377Scalar, Curve, Field, ProjectivePoint};
 
     #[test]
+    fn test_double_affine_curve() {
+        let mut g = Bls12377::GENERATOR_AFFINE;
+        let mut g2;
+        for _ in 0..2000 {
+            g2 = g.double();
+            g = g.to_projective().double().to_affine();
+            assert_eq!(g, g2);
+        }
+    }
+
+    #[test]
     fn test_naive_multiplication() {
         let g = Bls12377::GENERATOR_PROJECTIVE;
         let ten = Bls12377Scalar::from_canonical_u64(10);

--- a/src/curve/bls12_377_curve.rs
+++ b/src/curve/bls12_377_curve.rs
@@ -34,12 +34,12 @@ const BLS12_377_GENERATOR_Y: Bls12377Base = Bls12377Base {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Bls12377, Bls12377Scalar, Curve, Field, ProjectivePoint, hash_usize_to_curve};
+    use crate::{blake_hash_usize_to_curve, Bls12377, Bls12377Scalar, Curve, Field, ProjectivePoint};
 
     #[test]
     fn test_double_affine() {
         for i in 0..100 {
-            let p = hash_usize_to_curve::<Bls12377>(i, 128);
+            let p = blake_hash_usize_to_curve::<Bls12377>(i);
             assert_eq!(
                 p.double(),
                 p.to_projective().double().to_affine());

--- a/src/curve/bls12_377_curve.rs
+++ b/src/curve/bls12_377_curve.rs
@@ -34,16 +34,15 @@ const BLS12_377_GENERATOR_Y: Bls12377Base = Bls12377Base {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Bls12377, Bls12377Scalar, Curve, Field, ProjectivePoint};
+    use crate::{Bls12377, Bls12377Scalar, Curve, Field, ProjectivePoint, hash_usize_to_curve};
 
     #[test]
-    fn test_double_affine_curve() {
-        let mut g = Bls12377::GENERATOR_AFFINE;
-        let mut g2;
-        for _ in 0..2000 {
-            g2 = g.double();
-            g = g.to_projective().double().to_affine();
-            assert_eq!(g, g2);
+    fn test_double_affine() {
+        for i in 0..100 {
+            let p = hash_usize_to_curve::<Bls12377>(i, 128);
+            assert_eq!(
+                p.double(),
+                p.to_projective().double().to_affine());
         }
     }
 

--- a/src/curve/curve.rs
+++ b/src/curve/curve.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::many_single_char_names)]
+
 use std::ops::Neg;
 
 use anyhow::Result;
@@ -104,8 +105,29 @@ impl<C: Curve> AffinePoint<C> {
     }
 
     pub fn double(&self) -> Self {
-        // TODO: This is a very lazy implementation...
-        self.to_projective().double().to_affine()
+        // DONE: This is a very lazy implementation...
+        // self.to_projective().double().to_affine()
+        let AffinePoint {
+            x: x1,
+            y: y1,
+            zero: zero1,
+        } = *self;
+
+        if zero1 {
+            return AffinePoint::ZERO;
+        }
+        let double_y = y1.double();
+        let inv_double_y = double_y.multiplicative_inverse_assuming_nonzero(); // (2y) ^(-1)
+        let triple_xx = x1.square().triple(); // 3x^2
+        let lambda = (triple_xx + C::A) * inv_double_y;
+        let x3 = lambda.square() - self.x.double();
+        let y3 = lambda * (x1 - x3) - y1;
+
+        Self {
+            x: x3,
+            y: y3,
+            zero: false,
+        }
     }
 }
 

--- a/src/curve/curve.rs
+++ b/src/curve/curve.rs
@@ -107,6 +107,10 @@ impl<C: Curve> AffinePoint<C> {
     pub fn double(&self) -> Self {
         // DONE: This is a very lazy implementation...
         // self.to_projective().double().to_affine()
+        // According to the fact that output of the double operation
+        // should be AffinePoint and affine->projective->affine
+        // transformation is resource-intensive the below is changes
+        // for double operation in initial Affine definitions.
         let AffinePoint {
             x: x1,
             y: y1,

--- a/src/curve/curve.rs
+++ b/src/curve/curve.rs
@@ -105,23 +105,18 @@ impl<C: Curve> AffinePoint<C> {
     }
 
     pub fn double(&self) -> Self {
-        // DONE: This is a very lazy implementation...
-        // self.to_projective().double().to_affine()
-        // According to the fact that output of the double operation
-        // should be AffinePoint and affine->projective->affine
-        // transformation is resource-intensive the below is changes
-        // for double operation in initial Affine definitions.
         let AffinePoint {
             x: x1,
             y: y1,
-            zero: zero1,
+            zero,
         } = *self;
 
-        if zero1 {
+        if zero {
             return AffinePoint::ZERO;
         }
+
         let double_y = y1.double();
-        let inv_double_y = double_y.multiplicative_inverse_assuming_nonzero(); // (2y) ^(-1)
+        let inv_double_y = double_y.multiplicative_inverse_assuming_nonzero(); // (2y)^(-1)
         let triple_xx = x1.square().triple(); // 3x^2
         let lambda = (triple_xx + C::A) * inv_double_y;
         let x3 = lambda.square() - self.x.double();


### PR DESCRIPTION
According to the fact that output of the double operation should be AffinePoint and _affine -> projective -> affine_ transformation is resource-intensive changes were done to fix it. Also, the changes below include little improvements without rewriting results.

Old implementation:
* 11 additions and 12 multiplications for addition operation at projective coordinates;
* 2 multiplications and 1 inverse element search for transition from projective to affine coordinates.

New implementation:
* 1 inverse element search, 7 additions and 4 multiplications.

Speed comparison of the old and new implementations is presented below:

| version        | time (us)       |
| ------------- |:-------------:|
| old    | 8.1654  |
| new      | **7.4816** |