### PR TITLE
Field::exp improvement

### DIFF
--- a/benches/bls12_base.rs
+++ b/benches/bls12_base.rs
@@ -33,7 +33,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     }));
 
     c.bench_function("Bls12Base field exp", move |b| b.iter(|| {
-        black_box(x).exp_(black_box(y))
+        black_box(x).exp(black_box(y))
     }));
 
 }

--- a/benches/bls12_base.rs
+++ b/benches/bls12_base.rs
@@ -31,6 +31,11 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Bls12Base field inversion", move |b| b.iter(|| {
         black_box(x).multiplicative_inverse()
     }));
+
+    c.bench_function("Bls12Base field exp", move |b| b.iter(|| {
+        black_box(x).exp_(black_box(y))
+    }));
+
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/bls12_scalar.rs
+++ b/benches/bls12_scalar.rs
@@ -35,6 +35,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Bls12Scalar Rescue hash", move |b| b.iter(|| {
         rescue_hash_1_to_1(black_box(x), 128)
     }));
+
+    c.bench_function("Bls12Scalar field exp", move |b| b.iter(|| {
+        black_box(x).exp_(black_box(y))
+    }));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/bls12_scalar.rs
+++ b/benches/bls12_scalar.rs
@@ -37,7 +37,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     }));
 
     c.bench_function("Bls12Scalar field exp", move |b| b.iter(|| {
-        black_box(x).exp_(black_box(y))
+        black_box(x).exp(black_box(y))
     }));
 }
 

--- a/benches/tweedledee_base.rs
+++ b/benches/tweedledee_base.rs
@@ -33,7 +33,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     }));
 
     c.bench_function("TweedledeeBase field exp", move |b| b.iter(|| {
-        black_box(x).exp_(black_box(y))
+        black_box(x).exp(black_box(y))
     }));
 }
 

--- a/benches/tweedledee_base.rs
+++ b/benches/tweedledee_base.rs
@@ -31,6 +31,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("TweedledeeBase field inversion", move |b| b.iter(|| {
         black_box(x).multiplicative_inverse()
     }));
+
+    c.bench_function("TweedledeeBase field exp", move |b| b.iter(|| {
+        black_box(x).exp_(black_box(y))
+    }));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -316,8 +316,9 @@ pub trait Field:
 
         for limb in power.to_canonical_u64_vec().iter() {
             for j in 0..min(64, power_bits) {
-                // Check was initiated every time inside the loop,now it has moved out
-                // when creating the loop.
+                //The rust compiler does not unwrap a 64-range cycle,
+                // so a fixed check has no benefit. Thats ’why if statements
+                // has been taken out of the cycle to improve performance.
                 if (limb >> j & 1) != 0 {
                     product = product * current;
                 }

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::cmp::{Ordering, min};
 use std::cmp::Ordering::Equal;
 use std::collections::HashSet;
 use std::fmt::{Debug, Display};

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -315,17 +315,16 @@ pub trait Field:
         let mut product = Self::ONE;
 
         for limb in power.to_canonical_u64_vec().iter() {
+            // To minimize branching, it's better to iterate up to the min than to conditionally
+            // break inside the loop.
             for j in 0..min(64, power_bits) {
-                //The rust compiler does not unwrap a 64-range cycle,
-                // so a fixed check has no benefit. Thats ’why if statements
-                // has been taken out of the cycle to improve performance.
                 if (limb >> j & 1) != 0 {
                     product = product * current;
                 }
                 current = current.square();
             }
             if power_bits >= 64 {
-                power_bits = power_bits - 64;
+                power_bits -= 64;
             } else {
                 break;
             }

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -310,25 +310,25 @@ pub trait Field:
     }
 
     fn exp(&self, power: Self) -> Self {
-        let power_bits = power.num_bits();
+        let mut power_bits = power.num_bits();
         let mut current = *self;
         let mut product = Self::ONE;
 
-        for (i, limb) in power.to_canonical_u64_vec().iter().enumerate() {
-            for j in 0..64 {
-                // If we've gone through all the 1 bits already, no need to keep squaring.
-                let bit_index = i * 64 + j;
-                if bit_index == power_bits {
-                    return product;
-                }
-
+        for limb in power.to_canonical_u64_vec().iter() {
+            for j in 0..min(64, power_bits) {
+                // Check was initiated every time inside the loop,now it has moved out
+                // when creating the loop.
                 if (limb >> j & 1) != 0 {
                     product = product * current;
                 }
                 current = current.square();
             }
+            if power_bits >= 64 {
+                power_bits = power_bits - 64;
+            } else {
+                break;
+            }
         }
-
         product
     }
 


### PR DESCRIPTION
We have slightly accelerated the exponentiation algorithm. The Rust compiler does not unwrap a 64-range cycle, so a fixed check has no benefit. That's why **IF** statement has been taken out of cycle to improve performance.

Time measurements:
| version        | time (us)      |
| ------------- |:-------------:|
| old    | 9.7351 |
| new      | **9.1447** |

![image](https://user-images.githubusercontent.com/42472993/102119019-2b01b900-3e49-11eb-8a9c-3a0a21426f31.png)
![image](https://user-images.githubusercontent.com/42472993/102118903-ff7ece80-3e48-11eb-938b-de0f824f3228.png)