### PR TITLE
Field: k-th root improvement

### DIFF
--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -357,6 +357,9 @@ pub trait Field:
         let k_bu = field_to_biguint(k);
         let mut n = field_to_biguint(Self::ZERO);
         let mut numerator_bu = &p_minus_1_bu + BigUint::one();
+        //Added an improvement to avoid regularly transformation field_to_biguint
+        // for each iteration under cycle by using field_to_biguint transformation
+        // once outside the cycle.
         while n < k_bu {
             numerator_bu = numerator_bu + &p_minus_1_bu;
             if numerator_bu.is_multiple_of(&k_bu) {

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -354,16 +354,17 @@ pub trait Field:
         //    x^((p + n(p - 1))/k)^k = x,
         // implying that x^((p + n(p - 1))/k) is a k'th root of x.
         let p_minus_1_bu = field_to_biguint(Self::NEG_ONE);
-        let p_bu = &p_minus_1_bu + BigUint::one();
         let k_bu = field_to_biguint(k);
-        let mut n = Self::ZERO;
-        while n < k {
-            let numerator_bu = &p_bu + field_to_biguint(n) * &p_minus_1_bu;
+        let mut n = field_to_biguint(Self::ZERO);
+        let mut numerator_bu = &p_minus_1_bu + BigUint::one();
+        while n < k_bu {
+            numerator_bu = numerator_bu + &p_minus_1_bu;
             if numerator_bu.is_multiple_of(&k_bu) {
                 let power_bu = numerator_bu.div_floor(&k_bu).mod_floor(&p_minus_1_bu);
                 return self.exp(biguint_to_field(power_bu));
             }
-            n = n + Self::ONE;
+
+            n = n + BigUint::one();
         }
         panic!(
             "x^{} and x^(1/{}) are not permutations in this field, or we have a bug!",

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -360,13 +360,15 @@ pub trait Field:
         let mut numerator_bu = &p_minus_1_bu + BigUint::one();
 
         while n < k_bu {
+            // We can safely increment first, thus skipping the check for n=0, since n=0 will never
+            // satisfy the relation above.
+            n += BigUint::one();
             numerator_bu += &p_minus_1_bu;
+
             if numerator_bu.is_multiple_of(&k_bu) {
                 let power_bu = numerator_bu.div_floor(&k_bu).mod_floor(&p_minus_1_bu);
                 return self.exp(biguint_to_field(power_bu));
             }
-
-            n += BigUint::one();
         }
 
         panic!(

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -621,6 +621,7 @@ macro_rules! test_arithmetic {
     ($field:ty) => {
         mod arithmetic {
             use crate::{biguint_to_field, field_tests, field_to_biguint, Field};
+
             use num::{BigUint, Zero};
             use std::io::Result;
             use std::ops::{Add, Div, Mul, Neg, Sub};
@@ -740,6 +741,15 @@ macro_rules! test_arithmetic {
                     .collect::<Vec<_>>();
                 assert!(roots.iter().zip(inputs).all(|(&x, y)| x == y || x == -y));
                 Ok(())
+            }
+
+            #[test]
+            fn kth_root_consistent_with_exp() {
+                let degs = [5, 7, 11, 13, 17, 19, 23, 101];
+                for &deg in &degs {
+                    let num = <$field>::rand();
+                    assert_eq!(num, num.exp_u32(deg).kth_root_u32(deg));
+                }
             }
         }
     };

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -264,5 +264,13 @@ mod tests {
         assert_eq!(TweedledeeBase::is_valid_canonical_u64(&limbs), false);
     }
 
+    #[test]
+    fn valid_exp_kth_root() {
+        let degs = [5,7,11,13,17,19,23,101];
+        for i in 0..degs.len() {
+            let num = TweedledeeBase::rand();
+            assert_eq!(num, num.exp_u32(degs[i]).kth_root_u32(degs[i]));
+        }
+    }
     test_arithmetic!(crate::TweedledeeBase);
 }

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -264,14 +264,5 @@ mod tests {
         assert_eq!(TweedledeeBase::is_valid_canonical_u64(&limbs), false);
     }
 
-    #[test]
-    fn valid_exp_kth_root() {
-        let degs = [5, 7, 11, 13, 17, 19, 23, 101];
-        for &deg in &degs {
-            let num = TweedledeeBase::rand();
-            assert_eq!(num, num.exp_u32(deg).kth_root_u32(deg));
-        }
-    }
-
     test_arithmetic!(crate::TweedledeeBase);
 }

--- a/src/field/tweedledee_base.rs
+++ b/src/field/tweedledee_base.rs
@@ -266,11 +266,12 @@ mod tests {
 
     #[test]
     fn valid_exp_kth_root() {
-        let degs = [5,7,11,13,17,19,23,101];
-        for i in 0..degs.len() {
+        let degs = [5, 7, 11, 13, 17, 19, 23, 101];
+        for &deg in &degs {
             let num = TweedledeeBase::rand();
-            assert_eq!(num, num.exp_u32(degs[i]).kth_root_u32(degs[i]));
+            assert_eq!(num, num.exp_u32(deg).kth_root_u32(deg));
         }
     }
+
     test_arithmetic!(crate::TweedledeeBase);
 }


### PR DESCRIPTION
We have added an improvement to avoid regularly transformation field_to_biguint for each iteration inside of cycle by using field_to_biguint transformation once outside of cycle.

Below are time measurements:
| version        | time (us)      |
| ------------- |:-------------:|
| old    | 17.390 |
| new      | **12.291** |