### PR TITLE
Field: num bits improvement

### DIFF
--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -390,6 +390,10 @@ pub trait Field:
 
     /// The number of bits in the binary encoding of this field element.
     fn num_bits(&self) -> usize {
+        // It isn’t required to check each bit from left to right of the number
+        // to calculate the number of bits. You just need to check bits from right
+        // to left until you meet zero limbs. The below is the changes that propose
+        // it including a little improvements without rewriting result output each time.
         let mut n = 0;
         let vec = self.to_canonical_u64_vec();
         for (i, limb) in vec.iter().rev().enumerate() {

--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -371,6 +371,7 @@ pub trait Field:
         );
     }
 
+
     fn is_quadratic_residue(&self) -> bool {
         if self.is_zero() {
             return true;
@@ -390,16 +391,15 @@ pub trait Field:
     /// The number of bits in the binary encoding of this field element.
     fn num_bits(&self) -> usize {
         let mut n = 0;
-        for (i, limb) in self.to_canonical_u64_vec().iter().enumerate() {
-            for j in 0..64 {
-                if (limb >> j & 1) != 0 {
-                    n = i * 64 + j + 1;
-                }
+        let vec = self.to_canonical_u64_vec();
+        for (i, limb) in vec.iter().rev().enumerate() {
+            if *limb != 0 {
+                n = (vec.len() - i) * 64 - limb.leading_zeros() as usize;
+                break;
             }
         }
         n
     }
-
     /// Like `Ord::cmp`. We can't implement `Ord` directly due to Rust's trait coherence rules, so
     /// instead we provide this helper which implementations can use to trivially implement `Ord`.
     fn cmp_helper(&self, other: &Self) -> Ordering {


### PR DESCRIPTION
It isn’t required to check each bit of number from left to right to calculate the number of bits. You just need to check bits from right to left until you meet zero limbs. The changes below include little improvements without rewriting result.

Below are time measurements:
| version        | time (ns)      |
| ------------- |:-------------:|
| old    | 188.41 |
| new      | **87.340** |