### PR TITLE
Add check discriminant

### DIFF
--- a/src/curve/curve.rs
+++ b/src/curve/curve.rs
@@ -54,6 +54,11 @@ pub trait Curve: 'static + Sync + Sized + Copy + Debug {
         }
         Ok(res)
     }
+
+    fn is_safe_curve() -> bool{
+        // Added additional check to prevent using vulnerabilties in case a discriminant is equal to 0.
+        (Self::A.cube().double().double() + Self::B.square().triple().triple().triple()).is_nonzero()
+    }
 }
 
 /// A curve with the endomorphism described in the Halo paper, i.e. `phi((x, y)) = (zeta_p x, y)`,
@@ -107,6 +112,7 @@ impl<C: Curve> AffinePoint<C> {
         // TODO: This is a very lazy implementation...
         self.to_projective().double().to_affine()
     }
+
 }
 
 impl<C: HaloCurve> AffinePoint<C> {

--- a/src/curve/tweedledee_curve.rs
+++ b/src/curve/tweedledee_curve.rs
@@ -72,4 +72,12 @@ mod tests {
             mul_naive(Tweedledee::ZETA_SCALAR, g.to_projective()).to_affine()
         );
     }
+
+    #[test]
+    fn is_safe_curve() {
+        type C = Tweedledee;
+        assert!(
+           C::is_safe_curve()
+        );
+    }
 }

--- a/src/curve/tweedledum_curve.rs
+++ b/src/curve/tweedledum_curve.rs
@@ -87,4 +87,12 @@ mod tests {
             mul_naive(C::ZETA_SCALAR, g.to_projective()).to_affine()
         );
     }
+
+    #[test]
+    fn is_safe_curve() {
+        type C = Tweedledum;
+        assert!(
+            C::is_safe_curve()
+        );
+    }
 }


### PR DESCRIPTION
We have added an additional check to prevent attacks in case when the discriminant is equal to zero. You can read more  [this](https://www.dima.unige.it/~morafe/MaterialeCTC/p80-menezes.pdf) and [this](https://mathworld.wolfram.com/EllipticDiscriminant.html)
