### PR TITLE
Fix/expand test input for kth root test.

### DIFF
--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -743,10 +743,35 @@ macro_rules! test_arithmetic {
                 Ok(())
             }
 
+            /// Basic GCD algo; replace with Binary GCD for better performance.
+            fn gcd(x: BigUint, y: u32) -> u32 {
+                // TODO: This function probably belongs somewhere else, but at
+                // present is only used in kth_root_consistent_with_exp below.
+
+                use num::ToPrimitive;
+
+                let r = x % y;
+                if r.is_zero() {
+                    y
+                } else {
+                    let mut a = y;
+                    let mut b = r.to_u32().unwrap();
+                    while b != 0u32 {
+                        let t = a % b;
+                        a = b;
+                        b = t;
+                    }
+                    a
+                }
+            }
+
             #[test]
             fn kth_root_consistent_with_exp() {
-                let degs = [5, 7, 11, 13, 17, 19, 23, 101];
-                for &deg in &degs {
+                // We only test degrees that are coprime q-1 as these are
+                // the ones that give rise to permutations.
+                let degs = (3u32..101).step_by(2)
+                    .filter(|&x| gcd(field_to_biguint(<$field>::NEG_ONE), x) == 1u32);
+                for deg in degs {
                     let num = <$field>::rand();
                     assert_eq!(num, num.exp_u32(deg).kth_root_u32(deg));
                 }


### PR DESCRIPTION
The `kth_root_consistent_with_exp` test added in #93 includes some inputs that are invalid for some fields; in particular the test fails on the `Bls12377Scalar` and `Bls12377Base` fields. (These are not currently used AFAIK, but they helped to identify this issue in this case.)

Specifically the degrees specified [here](https://github.com/mir-protocol/plonky/pull/93/files#diff-76cc81a01fafe86577994ea59bd7367a25c82a95900cd38596dca072bb7a4ec9R748) include the value 5, however `x^5` is not a permutation on Bls12377Scalar so `kth_root()` panics. Similarly, degrees 7 and 13 that are in the test do not give permutations of either of the BLS12-377 fields.

The fix is to check the condition required for a given degree to give a permutation, namely that the degree is coprime to q-1 where q is the field size. Note this also allows non-prime degrees, whereas all the original test degrees were all prime for some reason. The `kth_root_consistent_with_exp` test now includes all possible candidate degrees up to 101.