### PR TITLE
Implement support for the Pasta curves

### DIFF
--- a/src/curve/mod.rs
+++ b/src/curve/mod.rs
@@ -6,6 +6,8 @@ pub use curve_multiplication::*;
 pub use curve_summations::*;
 pub use tweedledee_curve::*;
 pub use tweedledum_curve::*;
+pub use pallas_curve::*;
+pub use vesta_curve::*;
 
 mod bls12_377_curve;
 #[allow(clippy::module_inception)]
@@ -16,3 +18,5 @@ mod curve_multiplication;
 mod curve_summations;
 mod tweedledee_curve;
 mod tweedledum_curve;
+mod pallas_curve;
+mod vesta_curve;

--- a/src/curve/pallas_curve.rs
+++ b/src/curve/pallas_curve.rs
@@ -1,0 +1,81 @@
+use crate::{AffinePoint, Curve, Field, HaloCurve, PallasBase, VestaBase};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
+pub struct Pallas;
+
+impl Curve for Pallas {
+    type BaseField = PallasBase;
+    type ScalarField = VestaBase;
+
+    const A: PallasBase = PallasBase::ZERO;
+    const B: PallasBase = PallasBase::FIVE;
+
+    const GENERATOR_AFFINE: AffinePoint<Self> = AffinePoint {
+        x: PallasBase::NEG_ONE,
+        y: PallasBase::TWO,
+        zero: false,
+    };
+}
+
+impl HaloCurve for Pallas {
+    // See https://github.com/zcash/pasta/blob/fb448f35380263143160b6f190cca110858b0473/amicable.sage#L149
+    // for how to find zeta and "zeta scalar"
+    const ZETA: Self::BaseField = PallasBase {
+        limbs: [
+            0xfbdfd7aa9e65eac8, 0x0cd4d654e50025fb,
+            0xd59892a33785b99a, 0x2a27fb62585e8789
+        ],
+    };
+    const ZETA_SCALAR: Self::ScalarField = VestaBase {
+        limbs: [
+            0x410e7d207feeeee3, 0x6afdf14fd8fa2279,
+            0xfd3d8a04eca4d4d7, 0x2de2d60777dba4ef
+        ],
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::{Curve, HaloCurve, ProjectivePoint};
+    use crate::{Field, Pallas};
+
+    /// A simple, somewhat inefficient implementation of multiplication which is used as a reference
+    /// for correctness.
+    fn mul_naive(
+        lhs: <Pallas as Curve>::ScalarField,
+        rhs: ProjectivePoint<Pallas>,
+    ) -> ProjectivePoint<Pallas> {
+        let mut g = rhs;
+        let mut sum = ProjectivePoint::ZERO;
+        for limb in lhs.to_canonical().iter() {
+            for j in 0..64 {
+                if (limb >> j & 1u64) != 0u64 {
+                    sum = sum + g;
+                }
+                g = g.double();
+            }
+        }
+        sum
+    }
+
+    #[test]
+    fn test_endomorphism_pallas() {
+        type C = Pallas;
+        let g = C::convert(<C as Curve>::ScalarField::rand()) * C::GENERATOR_PROJECTIVE;
+        let g = g.to_affine();
+        let h = g.endomorphism();
+        assert_eq!(
+            h,
+            mul_naive(Pallas::ZETA_SCALAR, g.to_projective()).to_affine()
+        );
+    }
+
+    #[test]
+    fn is_safe_curve() {
+        type C = Pallas;
+        assert!(
+           C::is_safe_curve()
+        );
+    }
+}

--- a/src/curve/vesta_curve.rs
+++ b/src/curve/vesta_curve.rs
@@ -1,0 +1,79 @@
+use crate::{AffinePoint, Curve, Field, HaloCurve, PallasBase, VestaBase};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
+pub struct Vesta;
+
+impl Curve for Vesta {
+    type BaseField = VestaBase;
+    type ScalarField = PallasBase;
+
+    const A: VestaBase = VestaBase::ZERO;
+    const B: VestaBase = VestaBase::FIVE;
+
+    const GENERATOR_AFFINE: AffinePoint<Self> = AffinePoint {
+        x: VestaBase::NEG_ONE,
+        y: VestaBase::TWO,
+        zero: false,
+    };
+}
+
+impl HaloCurve for Vesta {
+    const ZETA: Self::BaseField = VestaBase {
+        limbs: [
+            0x410e7d207feeeee3, 0x6afdf14fd8fa2279,
+            0xfd3d8a04eca4d4d7, 0x2de2d60777dba4ef
+        ]
+    };
+    const ZETA_SCALAR: Self::ScalarField = PallasBase {
+        limbs: [
+            0xfbdfd7aa9e65eac8, 0x0cd4d654e50025fb,
+            0xd59892a33785b99a, 0x2a27fb62585e8789
+        ]
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::{Curve, HaloCurve, ProjectivePoint};
+    use crate::{Vesta, Field};
+
+    /// A simple, somewhat inefficient implementation of multiplication which is used as a reference
+    /// for correctness.
+    fn mul_naive(
+        lhs: <Vesta as Curve>::ScalarField,
+        rhs: ProjectivePoint<Vesta>,
+    ) -> ProjectivePoint<Vesta> {
+        let mut g = rhs;
+        let mut sum = ProjectivePoint::ZERO;
+        for limb in lhs.to_canonical().iter() {
+            for j in 0..64 {
+                if (limb >> j & 1u64) != 0u64 {
+                    sum = sum + g;
+                }
+                g = g.double();
+            }
+        }
+        sum
+    }
+
+    #[test]
+    fn test_endomorphism_vesta() {
+        type C = Vesta;
+        let g = C::convert(<C as Curve>::ScalarField::rand()) * C::GENERATOR_PROJECTIVE;
+        let g = g.to_affine();
+        let h = g.endomorphism();
+        assert_eq!(
+            h,
+            mul_naive(C::ZETA_SCALAR, g.to_projective()).to_affine()
+        );
+    }
+
+    #[test]
+    fn is_safe_curve() {
+        type C = Vesta;
+        assert!(
+            C::is_safe_curve()
+        );
+    }
+}

--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -4,6 +4,8 @@ pub use field::*;
 pub use tweedledee_base::*;
 pub use tweedledum_base::*;
 pub use monty::*;
+pub use pallas_base::*;
+pub use vesta_base::*;
 
 mod bls12_377_base;
 mod bls12_377_scalar;
@@ -12,3 +14,5 @@ mod field;
 mod tweedledee_base;
 mod tweedledum_base;
 mod monty;
+mod pallas_base;
+mod vesta_base;

--- a/src/field/pallas_base.rs
+++ b/src/field/pallas_base.rs
@@ -1,0 +1,268 @@
+use rand::Rng;
+use std::cmp::Ordering;
+use std::cmp::Ordering::Less;
+use std::convert::TryInto;
+use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+
+use crate::{cmp, field_to_biguint,
+            rand_range, rand_range_from_rng,
+            MontyRepr, Field};
+
+/// An element of the Pallas group's base field.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
+pub struct PallasBase {
+    /// Montgomery representation, encoded with little-endian u64 limbs.
+    pub limbs: [u64; 4],
+}
+
+impl MontyRepr for PallasBase {
+    /// The order of the field: 0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001
+    const ORDER: [u64; 4] = [
+        0x992d30ed00000001,
+        0x224698fc094cf91b,
+        0x0,
+        0x4000000000000000,
+    ];
+
+    /// Twice the order of the field
+    #[allow(dead_code)]
+    const ORDER_X2: [u64; 4] = [
+        0x325a61da00000002,
+        0x448d31f81299f237,
+        0x0,
+        0x8000000000000000,
+    ];
+
+    /// R in the context of the Montgomery reduction, i.e. 2^256 % |F|.
+    const R: [u64; 4] = [
+        0x34786d38fffffffd,
+        0x992c350be41914ad,
+        0xffffffffffffffff,
+        0x3fffffffffffffff
+    ];
+
+    /// R^2 in the context of the Montgomery reduction, i.e. 2^(256*2) % |F|.
+    const R2: [u64; 4] = [
+        0x8c78ecb30000000f,
+        0xd7d30dbd8b0de0e7,
+        0x7797a99bc3c95d18,
+        0x96d41af7b9cb714
+    ];
+
+    /// R^3 in the context of the Montgomery reduction, i.e. 2^(256*3) % |F|.
+    const R3: [u64; 4] = [
+        0xf185a5993a9e10f9,
+        0xf6a68f3b6ac5b1d1,
+        0xdf8d1014353fd42c,
+        0x2ae309222d2d9910
+    ];
+
+    /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
+    const MU: u64 = 0x992d30ecffffffff;
+}
+
+impl PallasBase {
+    pub fn from_canonical(c: [u64; 4]) -> Self {
+        Self { limbs: Self::from_monty(c) }
+    }
+
+    pub fn to_canonical(&self) -> [u64; 4] {
+        Self::to_monty(self.limbs)
+    }
+}
+
+impl Add<PallasBase> for PallasBase {
+    type Output = Self;
+
+    fn add(self, rhs: PallasBase) -> Self::Output {
+        Self { limbs: Self::monty_add(self.limbs, rhs.limbs) }
+    }
+}
+
+impl Sub<PallasBase> for PallasBase {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        Self { limbs: Self::monty_sub(self.limbs, rhs.limbs) }
+    }
+}
+
+impl Mul<PallasBase> for PallasBase {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
+        Self { limbs: Self::monty_multiply(self.limbs, rhs.limbs) }
+    }
+}
+
+impl Div<PallasBase> for PallasBase {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self {
+        self * rhs.multiplicative_inverse().expect("No inverse")
+    }
+}
+
+impl Neg for PallasBase {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Self { limbs: Self::monty_neg(self.limbs) }
+    }
+}
+
+impl Field for PallasBase {
+    const BITS: usize = 255;
+    const BYTES: usize = 32;
+    const ZERO: Self = Self { limbs: <Self as MontyRepr>::ZERO };
+    const ONE: Self = Self { limbs: <Self as MontyRepr>::ONE };
+    const TWO: Self = Self {
+        limbs: [
+            0xcfc3a984fffffff9,
+            0x1011d11bbee5303e,
+            0xffffffffffffffff,
+            0x3fffffffffffffff
+        ],
+    };
+    const THREE: Self = Self {
+        limbs: [
+            0x6b0ee5d0fffffff5,
+            0x86f76d2b99b14bd0,
+            0xfffffffffffffffe,
+            0x3fffffffffffffff
+        ],
+    };
+    const FOUR: Self = Self {
+        limbs: [
+            0x65a221cfffffff1,
+            0xfddd093b747d6762,
+            0xfffffffffffffffd,
+            0x3fffffffffffffff
+        ],
+    };
+    const FIVE: Self = Self {
+        limbs: [
+            0xa1a55e68ffffffed,
+            0x74c2a54b4f4982f3,
+            0xfffffffffffffffd,
+            0x3fffffffffffffff
+        ],
+    };
+    const NEG_ONE: Self = Self {
+        limbs: [0x64b4c3b400000004, 0x891a63f02533e46e, 0, 0]
+    };
+
+    const MULTIPLICATIVE_SUBGROUP_GENERATOR: Self = Self::FIVE;
+
+    const ALPHA: Self = Self::FIVE;
+
+    const TWO_ADICITY: usize = 32;
+
+    /// T = (ORDER - 1) / 2^TWO_ADICITY  in Monty form
+    const T: Self = Self {
+        limbs: [
+            0x992d30ed00000001,
+            0x224698fc094cf91b,
+            0x0,
+            0x3fffffff00000000
+        ],
+    };
+
+    fn to_canonical_u64_vec(&self) -> Vec<u64> {
+        self.to_canonical().to_vec()
+    }
+
+    fn from_canonical_u64_vec(v: Vec<u64>) -> Self {
+        Self::from_canonical(v[..].try_into().unwrap())
+    }
+
+    fn from_canonical_u64(n: u64) -> Self {
+        Self::from_canonical([n, 0, 0, 0])
+    }
+
+    fn is_valid_canonical_u64(v: &[u64]) -> bool {
+        v.len() == 4 && cmp(v[..].try_into().unwrap(), Self::ORDER) == Less
+    }
+
+    fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
+        Self {
+            limbs: Self::monty_inverse(self.limbs)
+        }
+    }
+
+    fn rand() -> Self {
+        Self {
+            limbs: rand_range(Self::ORDER),
+        }
+    }
+
+    fn rand_from_rng<R: Rng>(rng: &mut R) -> Self {
+        Self {
+            limbs: rand_range_from_rng(Self::ORDER, rng),
+        }
+    }
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        Self {
+            limbs: Self::monty_square(self.limbs),
+        }
+    }
+}
+
+impl Ord for PallasBase {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.cmp_helper(other)
+    }
+}
+
+impl PartialOrd for PallasBase {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Display for PallasBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", field_to_biguint(*self))
+    }
+}
+
+impl Debug for PallasBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "PallasBase {}", field_to_biguint(*self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_arithmetic;
+    use crate::Field;
+    use crate::PallasBase;
+    use crate::MontyRepr; // This is just to access ORDER_X2.
+
+    #[test]
+    fn primitive_root_order() {
+        for n_power in 0..10 {
+            let root = PallasBase::primitive_root_of_unity(n_power);
+            let order = PallasBase::generator_order(root);
+            assert_eq!(order, 1 << n_power, "2^{}'th primitive root", n_power);
+        }
+    }
+
+    #[test]
+    fn valid_canonical_vec() {
+        let small = <PallasBase as Field>::ONE.to_canonical_u64_vec();
+        assert!(PallasBase::is_valid_canonical_u64(&small));
+
+        let big = PallasBase::ORDER_X2.to_vec();
+        assert_eq!(PallasBase::is_valid_canonical_u64(&big), false);
+
+        let limbs = vec![1, 2, 3, 4, 5];
+        assert_eq!(PallasBase::is_valid_canonical_u64(&limbs), false);
+    }
+
+    test_arithmetic!(crate::PallasBase);
+}

--- a/src/field/vesta_base.rs
+++ b/src/field/vesta_base.rs
@@ -1,0 +1,255 @@
+use rand::Rng;
+use std::cmp::Ordering;
+use std::cmp::Ordering::Less;
+use std::convert::TryInto;
+use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+
+use crate::{cmp, field_to_biguint,
+            rand_range, rand_range_from_rng,
+            MontyRepr, Field};
+
+/// An element of the Vesta group's base field.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
+pub struct VestaBase {
+    /// Montgomery representation, encoded with little-endian u64 limbs.
+    pub limbs: [u64; 4],
+}
+
+impl MontyRepr for VestaBase {
+    /// The order of the field: 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001
+    const ORDER: [u64; 4] = [
+        0x8c46eb2100000001,
+        0x224698fc0994a8dd,
+        0x0,
+        0x4000000000000000
+    ];
+
+    /// Twice the order of the field:
+    #[allow(dead_code)]
+    const ORDER_X2: [u64; 4] = [
+        0x188dd64200000002,
+        0x448d31f8132951bb,
+        0x0,
+        0x8000000000000000
+    ];
+
+    /// R in the context of the Montgomery reduction, i.e. 2^256 % |F|.
+    const R: [u64; 4] = [
+        0x5b2b3e9cfffffffd,
+        0x992c350be3420567,
+        0xffffffffffffffff,
+        0x3fffffffffffffff
+    ];
+
+    /// R^2 in the context of the Montgomery reduction, i.e. 2^(256*2) % |F|.
+    const R2: [u64; 4] = [
+        0xfc9678ff0000000f,
+        0x67bb433d891a16e3,
+        0x7fae231004ccf590,
+        0x96d41af7ccfdaa9
+    ];
+
+    /// R^3 in the context of the Montgomery reduction, i.e. 2^(256*3) % |F|.
+    const R3: [u64; 4] = [
+        0x8b421c249dae4c,
+        0xe13bda50dba41326,
+        0x88fececb8e15cb63,
+        0x7dd97a06e6792c8
+    ];
+
+    /// In the context of Montgomery multiplication, µ = -|F|^-1 mod 2^64.
+    const MU: u64 = 0x8c46eb20ffffffff;
+}
+
+impl VestaBase {
+    pub fn from_canonical(c: [u64; 4]) -> Self {
+        Self { limbs: Self::from_monty(c) }
+    }
+
+    pub fn to_canonical(&self) -> [u64; 4] {
+        Self::to_monty(self.limbs)
+    }
+}
+
+impl Add<VestaBase> for VestaBase {
+    type Output = Self;
+
+    fn add(self, rhs: VestaBase) -> Self::Output {
+        Self { limbs: Self::monty_add(self.limbs, rhs.limbs) }
+    }
+}
+
+impl Sub<VestaBase> for VestaBase {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        Self { limbs: Self::monty_sub(self.limbs, rhs.limbs) }
+    }
+}
+
+impl Mul<VestaBase> for VestaBase {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
+        Self { limbs: Self::monty_multiply(self.limbs, rhs.limbs) }
+    }
+}
+
+impl Div<VestaBase> for VestaBase {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self {
+        self * rhs.multiplicative_inverse().expect("No inverse")
+    }
+}
+
+impl Neg for VestaBase {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Self { limbs: Self::monty_neg(self.limbs) }
+    }
+}
+
+impl Field for VestaBase {
+    const BITS: usize = 255;
+    const BYTES: usize = 32;
+    const ZERO: Self = Self { limbs: <Self as MontyRepr>::ZERO };
+    const ONE: Self = Self { limbs: <Self as MontyRepr>::ONE };
+    const TWO: Self = Self {
+        limbs: [
+            0x2a0f9218fffffff9,
+            0x1011d11bbcef61f1,
+            0xffffffffffffffff,
+            0x3fffffffffffffff
+        ],
+    };
+    const THREE: Self = Self {
+        limbs: [
+            0xf8f3e594fffffff5,
+            0x86f76d2b969cbe7a,
+            0xfffffffffffffffe,
+            0x3fffffffffffffff
+        ],
+    };
+    const FOUR: Self = Self {
+        limbs: [
+            0xc7d83910fffffff1,
+            0xfddd093b704a1b04,
+            0xfffffffffffffffd,
+            0x3fffffffffffffff
+        ],
+    };
+    const FIVE: Self = Self {
+        limbs: [
+            0x96bc8c8cffffffed,
+            0x74c2a54b49f7778e,
+            0xfffffffffffffffd,
+            0x3fffffffffffffff
+        ],
+    };
+    const NEG_ONE: Self = Self {
+        limbs: [0x311bac8400000004, 0x891a63f02652a376, 0, 0]
+    };
+
+    const MULTIPLICATIVE_SUBGROUP_GENERATOR: Self = Self::FIVE;
+
+    const ALPHA: Self = Self::FIVE;
+
+    const TWO_ADICITY: usize = 32;
+
+    /// T = (ORDER - 1) / 2^TWO_ADICITY  in Monty form
+    const T: Self = Self {
+        limbs: [
+            0x8c46eb2100000001,
+            0x224698fc0994a8dd,
+            0x0,
+            0x3fffffff00000000
+        ],
+    };
+
+    fn to_canonical_u64_vec(&self) -> Vec<u64> {
+        self.to_canonical().to_vec()
+    }
+
+    fn from_canonical_u64_vec(v: Vec<u64>) -> Self {
+        Self::from_canonical(v[..].try_into().unwrap())
+    }
+
+    fn from_canonical_u64(n: u64) -> Self {
+        Self::from_canonical([n, 0, 0, 0])
+    }
+
+    fn is_valid_canonical_u64(v: &[u64]) -> bool {
+        v.len() == 4 && cmp(v[..].try_into().unwrap(), Self::ORDER) == Less
+    }
+
+    fn multiplicative_inverse_assuming_nonzero(&self) -> Self {
+        Self {
+            limbs: Self::monty_inverse(self.limbs)
+        }
+    }
+
+    fn rand() -> Self {
+        Self {
+            limbs: rand_range(Self::ORDER),
+        }
+    }
+
+    fn rand_from_rng<R: Rng>(rng: &mut R) -> Self {
+        Self {
+            limbs: rand_range_from_rng(Self::ORDER, rng),
+        }
+    }
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        Self {
+            limbs: Self::monty_square(self.limbs),
+        }
+    }
+}
+
+impl Ord for VestaBase {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.cmp_helper(other)
+    }
+}
+
+impl PartialOrd for VestaBase {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Display for VestaBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", field_to_biguint(*self))
+    }
+}
+
+impl Debug for VestaBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "VestaBase({})", field_to_biguint(*self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_arithmetic;
+    use crate::Field;
+    use crate::VestaBase;
+
+    #[test]
+    fn primitive_root_order() {
+        for n_power in 0..10 {
+            let root = VestaBase::primitive_root_of_unity(n_power);
+            let order = VestaBase::generator_order(root);
+            assert_eq!(order, 1 << n_power, "2^{}'th primitive root", n_power);
+        }
+    }
+
+    test_arithmetic!(crate::VestaBase);
+}

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,4 +1,4 @@
-use crate::{AffinePoint, Curve, Field, TweedledumBase, Bls12377Base, Bls12377Scalar, TweedledeeBase};
+use crate::{AffinePoint, Curve, Field, TweedledumBase, Bls12377Base, Bls12377Scalar, TweedledeeBase, PallasBase, VestaBase};
 use serde::de::Error as DeError;
 use serde::de::Visitor;
 use serde::ser::Error as SerdeError;
@@ -151,11 +151,16 @@ impl_serde_field!(TweedledumBase);
 impl_serde_field!(TweedledeeBase);
 impl_serde_field!(Bls12377Base);
 impl_serde_field!(Bls12377Scalar);
+impl_serde_field!(PallasBase);
+impl_serde_field!(VestaBase);
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{blake_hash_base_field_to_curve, Bls12377, Bls12377Base, Bls12377Scalar, CircuitBuilder, HaloCurve, PartialWitness, Proof, Tweedledee, TweedledeeBase, Tweedledum, TweedledumBase, VerificationKey};
+    use crate::{blake_hash_base_field_to_curve, CircuitBuilder, HaloCurve, PartialWitness, Proof, VerificationKey};
+    use crate::{Bls12377, Bls12377Base, Bls12377Scalar};
+    use crate::{Tweedledee, TweedledeeBase, Tweedledum, TweedledumBase};
+    use crate::{Pallas, PallasBase, Vesta, VestaBase};
     use anyhow::Result;
 
     macro_rules! test_field_serialization {
@@ -213,10 +218,22 @@ mod test {
         };
     }
 
+    test_field_serialization!(PallasBase, test_pallas_base_serialization);
+    test_field_serialization!(VestaBase, test_vesta_base_serialization);
     test_field_serialization!(TweedledeeBase, test_tweedledee_base_serialization);
     test_field_serialization!(TweedledumBase, test_tweedledum_base_serialization);
     test_field_serialization!(Bls12377Base, test_bls_base_serialization);
     test_field_serialization!(Bls12377Scalar, test_bls_scalar_serialization);
+    test_curve_serialization!(
+        Pallas,
+        <Pallas as Curve>::BaseField,
+        test_pallas_curve_serialization
+    );
+    test_curve_serialization!(
+        Vesta,
+        <Vesta as Curve>::BaseField,
+        test_vesta_curve_serialization
+    );
     test_curve_serialization!(
         Tweedledee,
         <Tweedledee as Curve>::BaseField,
@@ -307,4 +324,6 @@ mod test {
 
     test_proof_vk_serialization!(Tweedledee, Tweedledum, test_proof_vk_serialization_tweedledee);
     test_proof_vk_serialization!(Tweedledum, Tweedledee, test_proof_vk_serialization_tweedledum);
+    test_proof_vk_serialization!(Pallas, Vesta, test_proof_vk_serialization_pallas);
+    test_proof_vk_serialization!(Vesta, Pallas, test_proof_vk_serialization_vesta);
 }


### PR DESCRIPTION
This PR implements support for the [Pasta curve pair](https://electriccoin.co/blog/the-pasta-curves-for-halo-2-and-beyond/) which provide some benefits over the Tweedle* curve pair.

This PR does not attempt to implement any of the performance improvements mentioned in the aforementioned reference; the benefits such are likely to be fairly modest.

Most of the work was just converting the published constants into Montgomery form and pasting them into the right slots. This means that there is some additional duplication with the other field and curve implementations; this will be refactored in due course. The only exception to this was the choice of the `ZETA` and `ZETA_SCALAR` parameters which are not mandated by the Pasta curves, just their properties; so a choice was made and set in the implementation.